### PR TITLE
PR: Unified Authentication Strategy (OAuth & ADC Support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 JWT_SECRET=$(openssl rand -base64 32)
 BASE_URL=http://localhost:8080
+AUTH_MODE=oauth
 EOF
 
 # Start the server
@@ -227,6 +228,13 @@ docker compose up -d
 # Add to Claude
 claude mcp add -t http gtm http://localhost:8080
 ```
+
+### Authentication Modes
+
+The server supports two authentication modes, configurable via the `AUTH_MODE` environment variable:
+
+- **`oauth` (Default)**: Interactive user flow. Users must sign in with their Google account through a browser. Best for personal use or multi-user environments.
+- **`adc`**: Server-side Application Default Credentials. The server uses its own Service Account identity (via `GOOGLE_APPLICATION_CREDENTIALS` or GCP metadata) to talk to GTM. Best for automated/headless environments or Cloud Run deployments.
 
 #### Docker-to-Docker
 

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -12,4 +12,11 @@ import (
 type TokenProvider interface {
 	// GetTokenSource returns a TokenSource based on the request context and/or HTTP request.
 	GetTokenSource(ctx context.Context, req *http.Request) (oauth2.TokenSource, error)
+
+	// IsAuthenticated returns true if the current context/environment is authenticated.
+	IsAuthenticated(ctx context.Context) bool
+
+	// VerifyAccess performs an active check against the downstream service (GTM).
+	// It should implement caching to prevent rate-limiting.
+	VerifyAccess(ctx context.Context) error
 }

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -1,0 +1,15 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// TokenProvider is an interface for obtaining an OAuth2 TokenSource.
+// This allows different authentication strategies (e.g. user OAuth vs server-side ADC).
+type TokenProvider interface {
+	// GetTokenSource returns a TokenSource based on the request context and/or HTTP request.
+	GetTokenSource(ctx context.Context, req *http.Request) (oauth2.TokenSource, error)
+}

--- a/auth/provider_server_adc.go
+++ b/auth/provider_server_adc.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// ServerADCProvider implements TokenProvider using Google Application Default Credentials (ADC).
+type ServerADCProvider struct {
+	scopes []string
+}
+
+// NewServerADCProvider creates a new ServerADCProvider with the given scopes.
+func NewServerADCProvider(scopes []string) *ServerADCProvider {
+	return &ServerADCProvider{
+		scopes: scopes,
+	}
+}
+
+// GetTokenSource ignores the request and context, and uses the server's environment credentials.
+func (p *ServerADCProvider) GetTokenSource(ctx context.Context, _ *http.Request) (oauth2.TokenSource, error) {
+	tokenSource, err := google.DefaultTokenSource(ctx, p.scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ADC token source: %w", err)
+	}
+	return tokenSource, nil
+}

--- a/auth/provider_server_adc.go
+++ b/auth/provider_server_adc.go
@@ -4,20 +4,30 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+	"google.golang.org/api/tagmanager/v2"
 )
 
 // ServerADCProvider implements TokenProvider using Google Application Default Credentials (ADC).
 type ServerADCProvider struct {
 	scopes []string
+
+	mu            sync.RWMutex
+	isValidated   bool
+	lastChecked   time.Time
+	checkInterval time.Duration
 }
 
 // NewServerADCProvider creates a new ServerADCProvider with the given scopes.
 func NewServerADCProvider(scopes []string) *ServerADCProvider {
 	return &ServerADCProvider{
-		scopes: scopes,
+		scopes:        scopes,
+		checkInterval: 5 * time.Minute,
 	}
 }
 
@@ -28,4 +38,61 @@ func (p *ServerADCProvider) GetTokenSource(ctx context.Context, _ *http.Request)
 		return nil, fmt.Errorf("failed to get ADC token source: %w", err)
 	}
 	return tokenSource, nil
+}
+
+// IsAuthenticated returns true for ADC as it uses server-side credentials.
+func (p *ServerADCProvider) IsAuthenticated(ctx context.Context) bool {
+	return true
+}
+
+// VerifyAccess performs an active check against the downstream service (GTM).
+func (p *ServerADCProvider) VerifyAccess(ctx context.Context) error {
+	p.mu.RLock()
+	if time.Since(p.lastChecked) < p.checkInterval {
+		if p.isValidated {
+			p.mu.RUnlock()
+			return nil
+		}
+		// If it previously failed but the interval hasn't passed, we still might want to re-check, 
+		// but typically we'd cache the failure too. For simplicity, let's cache success only or both.
+		// Let's cache both: if it was validated, return nil. If not, maybe retry or return error.
+		// Actually, let's just cache the validation state regardless.
+		p.mu.RUnlock()
+		// If not validated and we are within checkInterval, we could return a cached error,
+		// but let's just perform ping if it's not validated.
+	} else {
+		p.mu.RUnlock()
+	}
+
+	err := p.performPing(ctx)
+
+	p.mu.Lock()
+	p.isValidated = (err == nil)
+	p.lastChecked = time.Now()
+	p.mu.Unlock()
+
+	return err
+}
+
+// performPing attempts a minimal API call to verify actual GTM access.
+func (p *ServerADCProvider) performPing(ctx context.Context) error {
+	ts, err := p.GetTokenSource(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get token source for ping: %w", err)
+	}
+
+	// 1. Initialize the Tag Manager service client
+	srv, err := tagmanager.NewService(ctx, option.WithTokenSource(ts))
+	if err != nil {
+		return fmt.Errorf("failed to initialize GTM service for ping: %w", err)
+	}
+
+	// 2. Perform a lightweight, read-only API call. 
+	// Listing accounts is usually the safest "whoami" equivalent for GTM.
+	_, err = srv.Accounts.List().Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("GTM access verification failed: %w", err)
+	}
+
+	return nil
 }

--- a/auth/provider_user_oauth.go
+++ b/auth/provider_user_oauth.go
@@ -4,16 +4,27 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
 	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	"google.golang.org/api/tagmanager/v2"
 )
 
 // UserOAuthProvider implements TokenProvider using the context set by the interactive OAuth middleware.
-type UserOAuthProvider struct{}
+type UserOAuthProvider struct {
+	mu            sync.RWMutex
+	isValidated   bool
+	lastChecked   time.Time
+	checkInterval time.Duration
+}
 
 // NewUserOAuthProvider creates a new UserOAuthProvider.
 func NewUserOAuthProvider() *UserOAuthProvider {
-	return &UserOAuthProvider{}
+	return &UserOAuthProvider{
+		checkInterval: 5 * time.Minute,
+	}
 }
 
 // GetTokenSource extracts the token info and dependencies from the context to create a TokenSource.
@@ -35,4 +46,59 @@ func (p *UserOAuthProvider) GetTokenSource(ctx context.Context, _ *http.Request)
 	)
 
 	return tokenSource, nil
+}
+
+// IsAuthenticated checks if the current context has a valid token.
+func (p *UserOAuthProvider) IsAuthenticated(ctx context.Context) bool {
+	return GetTokenInfo(ctx) != nil
+}
+
+// VerifyAccess performs an active check against the downstream service (GTM).
+func (p *UserOAuthProvider) VerifyAccess(ctx context.Context) error {
+	if !p.IsAuthenticated(ctx) {
+		return fmt.Errorf("not authenticated")
+	}
+
+	p.mu.RLock()
+	if time.Since(p.lastChecked) < p.checkInterval {
+		if p.isValidated {
+			p.mu.RUnlock()
+			return nil
+		}
+		p.mu.RUnlock()
+	} else {
+		p.mu.RUnlock()
+	}
+
+	err := p.performPing(ctx)
+
+	p.mu.Lock()
+	p.isValidated = (err == nil)
+	p.lastChecked = time.Now()
+	p.mu.Unlock()
+
+	return err
+}
+
+// performPing attempts a minimal API call to verify actual GTM access.
+func (p *UserOAuthProvider) performPing(ctx context.Context) error {
+	ts, err := p.GetTokenSource(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get token source for ping: %w", err)
+	}
+
+	// 1. Initialize the Tag Manager service client
+	srv, err := tagmanager.NewService(ctx, option.WithTokenSource(ts))
+	if err != nil {
+		return fmt.Errorf("failed to initialize GTM service for ping: %w", err)
+	}
+
+	// 2. Perform a lightweight, read-only API call. 
+	// Listing accounts is usually the safest "whoami" equivalent for GTM.
+	_, err = srv.Accounts.List().Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("GTM access verification failed: %w", err)
+	}
+
+	return nil
 }

--- a/auth/provider_user_oauth.go
+++ b/auth/provider_user_oauth.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// UserOAuthProvider implements TokenProvider using the context set by the interactive OAuth middleware.
+type UserOAuthProvider struct{}
+
+// NewUserOAuthProvider creates a new UserOAuthProvider.
+func NewUserOAuthProvider() *UserOAuthProvider {
+	return &UserOAuthProvider{}
+}
+
+// GetTokenSource extracts the token info and dependencies from the context to create a TokenSource.
+func (p *UserOAuthProvider) GetTokenSource(ctx context.Context, _ *http.Request) (oauth2.TokenSource, error) {
+	tokenInfo := GetTokenInfo(ctx)
+	if tokenInfo == nil || tokenInfo.GoogleToken == nil {
+		return nil, fmt.Errorf("not authenticated - please authenticate with Google first")
+	}
+
+	store := GetTokenStore(ctx)
+	googleProvider := GetGoogleProvider(ctx)
+
+	// Create auto-refreshing token source
+	tokenSource := NewAutoRefreshTokenSource(
+		store,
+		tokenInfo.AccessToken,
+		googleProvider.Config(),
+		tokenInfo.GoogleToken,
+	)
+
+	return tokenSource, nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,11 @@ type Config struct {
 	Port    int
 	BaseURL string
 
+	// Auth configuration
+	// AuthMode determines how the server authenticates with Google Tag Manager.
+	// Valid values: "oauth" (default, interactive user flow) or "adc" (server-side Application Default Credentials).
+	AuthMode string
+
 	// Google OAuth configuration
 	GoogleClientID     string
 	GoogleClientSecret string
@@ -46,6 +51,7 @@ func Load() (*Config, error) {
 	cfg := &Config{
 		Port:              getEnvInt("PORT", 8080),
 		BaseURL:           getEnv("BASE_URL", "http://localhost:8080"),
+		AuthMode:          getEnv("AUTH_MODE", "oauth"),
 		GoogleClientID:    getEnv("GOOGLE_CLIENT_ID", ""),
 		GoogleClientSecret: getEnv("GOOGLE_CLIENT_SECRET", ""),
 		GoogleRedirectURI: getEnv("GOOGLE_REDIRECT_URI", ""),

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -3,6 +3,7 @@ package gtm
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"gtm-mcp-server/auth"
 
@@ -10,7 +11,9 @@ import (
 )
 
 // RegisterTools adds all GTM tools to the MCP server.
-func RegisterTools(server *mcp.Server) {
+func RegisterTools(server *mcp.Server, tokenProvider auth.TokenProvider) {
+	globalTokenProvider = tokenProvider
+
 	// Read operations
 	registerListAccounts(server)
 	registerListContainers(server)
@@ -84,23 +87,22 @@ func RegisterTools(server *mcp.Server) {
 	RegisterPrompts(server)
 }
 
-// getClient creates a GTM client from the request context with auto-refreshing tokens.
+// globalTokenProvider holds the injected strategy for obtaining tokens.
+var globalTokenProvider auth.TokenProvider
+
+// getClient creates a GTM client using the injected token provider.
 func getClient(ctx context.Context) (*Client, error) {
-	tokenInfo := auth.GetTokenInfo(ctx)
-	if tokenInfo == nil || tokenInfo.GoogleToken == nil {
-		return nil, fmt.Errorf("not authenticated - please authenticate with Google first")
+	if globalTokenProvider == nil {
+		return nil, fmt.Errorf("token provider not configured")
 	}
 
-	store := auth.GetTokenStore(ctx)
-	google := auth.GetGoogleProvider(ctx)
-
-	// Create auto-refreshing token source
-	var tokenSource = auth.NewAutoRefreshTokenSource(
-		store,
-		tokenInfo.AccessToken,
-		google.Config(),
-		tokenInfo.GoogleToken,
-	)
+	// We pass a dummy request here as the user OAuth provider pulls from context.
+	// A more robust implementation might attach the *http.Request to context upstream.
+	dummyReq, _ := http.NewRequestWithContext(ctx, "GET", "/", nil)
+	tokenSource, err := globalTokenProvider.GetTokenSource(ctx, dummyReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token source: %w", err)
+	}
 
 	return NewClient(ctx, tokenSource)
 }

--- a/main.go
+++ b/main.go
@@ -55,9 +55,6 @@ func main() {
 	// Add logging middleware
 	server.AddReceivingMiddleware(middleware.NewLoggingMiddleware(logger))
 
-	// Register tools
-	registerTools(server)
-
 	// Create HTTP handler for MCP
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server
@@ -102,8 +99,17 @@ func main() {
 	oauthLimiter := middleware.NewRateLimiter(10, 20)   // 10 req/s, burst 20
 	registerLimiter := middleware.NewRateLimiter(2, 5)   // 2 req/s, burst 5
 
-	if oauthConfigured {
-		// Set up OAuth
+	var tokenProvider auth.TokenProvider
+
+	if cfg.AuthMode == "adc" {
+		logger.Info("using server-side Application Default Credentials (ADC) for GTM authentication")
+		tokenProvider = auth.NewServerADCProvider(auth.GoogleScopes)
+		
+		// In ADC mode, we don't need interactive OAuth middleware
+		mux.Handle("/", maxBytesHandler(5<<20, mcpHandler))
+	} else if oauthConfigured {
+		logger.Info("using interactive user OAuth flow for GTM authentication")
+		
 		tokenStore = auth.NewMemoryTokenStore()
 		googleProvider := auth.NewGoogleProvider(
 			cfg.GoogleClientID,
@@ -111,6 +117,8 @@ func main() {
 			cfg.BaseURL+"/oauth/callback",
 		)
 		authServer = auth.NewServer(cfg.BaseURL, googleProvider, tokenStore, logger, cfg.AccessTokenTTL)
+
+		tokenProvider = auth.NewUserOAuthProvider()
 
 		// OAuth endpoints with rate limiting and body size limits
 		mux.HandleFunc("GET /authorize", oauthLimiter.MiddlewareFunc(authServer.AuthorizeHandler))
@@ -134,6 +142,9 @@ func main() {
 	} else {
 		logger.Warn("OAuth not configured, running without authentication", "error", cfg.ValidateAuth())
 
+		// Fallback to UserOAuthProvider which will return errors when tools are called without tokens
+		tokenProvider = auth.NewUserOAuthProvider()
+
 		// Register OAuth endpoints that return proper errors
 		oauthNotConfiguredHandler := func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -151,6 +162,9 @@ func main() {
 		// MCP endpoint without auth (still apply body size limit)
 		mux.Handle("/", maxBytesHandler(5<<20, mcpHandler))
 	}
+
+	// Register tools
+	registerTools(server, tokenProvider)
 
 	// Create HTTP server
 	addr := fmt.Sprintf(":%d", cfg.Port)
@@ -195,9 +209,9 @@ func main() {
 }
 
 // registerTools adds MCP tools to the server.
-func registerTools(server *mcp.Server) {
+func registerTools(server *mcp.Server, tokenProvider auth.TokenProvider) {
 	registerUtilityTools(server)
-	gtm.RegisterTools(server)
+	gtm.RegisterTools(server, tokenProvider)
 }
 
 // maxBytesHandler wraps an http.Handler with a request body size limit.

--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func main() {
 
 // registerTools adds MCP tools to the server.
 func registerTools(server *mcp.Server, tokenProvider auth.TokenProvider) {
-	registerUtilityTools(server)
+	registerUtilityTools(server, tokenProvider)
 	gtm.RegisterTools(server, tokenProvider)
 }
 
@@ -225,7 +225,7 @@ func maxBytesHandler(maxBytes int64, next http.Handler) http.Handler {
 }
 
 // registerUtilityTools adds ping and auth_status tools.
-func registerUtilityTools(server *mcp.Server) {
+func registerUtilityTools(server *mcp.Server, tokenProvider auth.TokenProvider) {
 	// Ping tool for testing connectivity
 	type PingInput struct {
 		Message string `json:"message,omitempty" jsonschema:"Optional message to echo back"`
@@ -250,6 +250,7 @@ func registerUtilityTools(server *mcp.Server) {
 	type AuthStatusInput struct{}
 	type AuthStatusOutput struct {
 		Authenticated bool   `json:"authenticated"`
+		HasAccess     bool   `json:"has_access"`
 		Message       string `json:"message"`
 	}
 
@@ -257,13 +258,27 @@ func registerUtilityTools(server *mcp.Server) {
 		Name:        "auth_status",
 		Description: "Check authentication status with Google Tag Manager",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input AuthStatusInput) (*mcp.CallToolResult, AuthStatusOutput, error) {
-		tokenInfo := auth.GetTokenInfo(ctx)
-		output := AuthStatusOutput{Authenticated: tokenInfo != nil}
-		if tokenInfo != nil {
-			output.Message = "You are authenticated and can access GTM data"
-		} else {
-			output.Message = "Not authenticated. GTM tools will require authentication."
+		if !tokenProvider.IsAuthenticated(ctx) {
+			return nil, AuthStatusOutput{
+				Authenticated: false,
+				HasAccess:     false,
+				Message:       "No valid credentials found. Please log in.",
+			}, nil
 		}
-		return nil, output, nil
+
+		err := tokenProvider.VerifyAccess(ctx)
+		if err != nil {
+			return nil, AuthStatusOutput{
+				Authenticated: true,
+				HasAccess:     false,
+				Message:       fmt.Sprintf("Credentials are valid, but GTM access was denied. Ensure the account/service account has GTM permissions. Error: %v", err),
+			}, nil
+		}
+
+		return nil, AuthStatusOutput{
+			Authenticated: true,
+			HasAccess:     true,
+			Message:       "System is fully authenticated and authorized to access GTM.",
+		}, nil
 	})
 }


### PR DESCRIPTION
## Description
This PR refactors the authentication layer to support both **Interactive User OAuth** (existing) and **Server-Side Application Default Credentials (ADC)**. This allows the MCP server to run seamlessly in headless environments like Google Cloud Run or when using Service Account JSON keys.

### Key Changes
- **Architecture Refactor**: Implemented the **Strategy Pattern** via a new `auth.TokenProvider` interface. This decouples the GTM tool logic from how tokens are actually retrieved.
- **Pluggable Providers**:
    - `UserOAuthProvider`: Maintains support for the standard browser-based login flow.
    - `ServerADCProvider`: New provider that utilizes Google ADC for machine-to-machine authentication.
- **Startup Configuration**: Added a new `AUTH_MODE` environment variable (defaults to `oauth`).
    - `AUTH_MODE=adc`: Enables the server to use its own identity (Service Account) to talk to GTM, bypassing the interactive login middleware.
- **Dependency Injection**: Refactored `gtm.RegisterTools` to accept an injected `TokenProvider`, significantly improving testability and separation of concerns.
- **Documentation**: Updated `README.md` to include instructions for the new authentication modes and environment variables.

## Motivation

### 1. Universal Headless Support for AI Agents
Most current MCP clients (including **Claude Code**, **Gemini CLI**, and other headless agents) are primarily designed for interactive, browser-based OAuth flows. In automated, remote, or restricted environments (like CI/CD or cloud-hosted agents), performing a manual "Sign-in with Google" is often impossible. 

By allowing the MCP server to authenticate itself via ADC, we remove this friction and enable these agents to operate in **fully headless and automated workflows**.

### 2. Security & Principle of Least Privilege
This update enables the use of dedicated **GTM Agent Service Accounts**. Instead of granting an AI agent full access to a personal Google account, users can now provision a service account with fine-grained, restricted permissions (e.g., "Edit" but not "Publish") directly within the Google Tag Manager UI. This significantly improves the security posture for any project utilizing AI for tag management.

## How to Test

### 1. Test Interactive OAuth Mode (Backward Compatibility)
- **Setup**: In your `.env`, set `AUTH_MODE=oauth` (or leave it unset as it is the default). Ensure you have your `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` configured.
- **Verification**: Run the server and verify that attempting to use a GTM tool still triggers the standard 3-legged OAuth flow (opening a browser for sign-in).

### 2. Test Headless ADC Mode (New Feature)
- **Setup**: In your environment, set `AUTH_MODE=adc`. Ensure you have a valid Google Service Account (via `GOOGLE_APPLICATION_CREDENTIALS` or by running on a GCP resource with an attached service account).
- **Verification**: Run the server and verify that GTM tools can be called **immediately** without any browser interaction or "Sign-in with Google" prompt.

## Checklist
- [x] Code follows the Go style guide of the project.
- [x] Refactored logic maintains backward compatibility for existing OAuth users.
- [x] No sensitive credentials or secrets are included.
- [x] Architecture is decoupled and ready for unit testing.
- [x] Documentation in `README.md` has been updated.
