### PR TITLE
Include parameter array in tag and variable responses

### DIFF
--- a/gtm/tags.go
+++ b/gtm/tags.go
@@ -24,6 +24,7 @@ type Tag struct {
 	TagID             string              `json:"tagId"`
 	Name              string              `json:"name"`
 	Type              string              `json:"type"`
+	Parameter         any                 `json:"parameter,omitempty"`
 	FiringTriggerID   []string            `json:"firingTriggerId,omitempty"`
 	BlockingTriggerID []string            `json:"blockingTriggerId,omitempty"`
 	SetupTag          []TagSequenceRef    `json:"setupTag,omitempty"`
@@ -80,6 +81,9 @@ func toTag(t *tagmanager.Tag) Tag {
 		BlockingTriggerID: t.BlockingTriggerId,
 		Paused:            t.Paused,
 		Path:              t.Path,
+	}
+	if len(t.Parameter) > 0 {
+		tag.Parameter = t.Parameter
 	}
 	for _, s := range t.SetupTag {
 		tag.SetupTag = append(tag.SetupTag, TagSequenceRef{

--- a/gtm/variables.go
+++ b/gtm/variables.go
@@ -12,6 +12,7 @@ type Variable struct {
 	VariableID string `json:"variableId"`
 	Name       string `json:"name"`
 	Type       string `json:"type"`
+	Parameter  any    `json:"parameter,omitempty"`
 	Path       string `json:"path"`
 }
 
@@ -47,18 +48,25 @@ func (c *Client) GetVariable(ctx context.Context, accountID, containerID, worksp
 		Type:       v.Type,
 		Path:       v.Path,
 	}
+	if len(v.Parameter) > 0 {
+		result.Parameter = v.Parameter
+	}
 	return &result, nil
 }
 
 func toVariables(variables []*tagmanager.Variable) []Variable {
 	result := make([]Variable, 0, len(variables))
 	for _, v := range variables {
-		result = append(result, Variable{
+		variable := Variable{
 			VariableID: v.VariableId,
 			Name:       v.Name,
 			Type:       v.Type,
 			Path:       v.Path,
-		})
+		}
+		if len(v.Parameter) > 0 {
+			variable.Parameter = v.Parameter
+		}
+		result = append(result, variable)
 	}
 	return result
 }


### PR DESCRIPTION
## Summary

- Add missing `parameter` field to `Tag` and `Variable` response structs
- Map the field in `toTag()`, `GetVariable()`, and `toVariables()`

## Problem

The `parameter` array from the Google GTM API was being silently dropped during response serialization. This meant:

- **Custom HTML tags** returned `type: "html"` but no way to see the actual `<script>...</script>` content
- **GA4 tags** returned no measurement ID or event parameters
- **Variables** returned no data layer path, lookup table config, or regex patterns

Triggers, clients, and transformations already included `parameter` — tags and variables were the only entities missing it.