### PR TITLE
fix(auth): close SSRF bypasses in the CIMD metadata fetch

### DIFF
--- a/auth/cimd.go
+++ b/auth/cimd.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -23,6 +24,7 @@ const (
 	cimdFetchTimeout = 10 * time.Second
 	cimdDefaultTTL   = 5 * time.Minute
 	cimdMaxTTL       = 24 * time.Hour
+	cimdMaxRedirects = 5
 )
 
 // IsClientIDMetadataURL reports whether clientID is a valid CIMD identifier:
@@ -65,10 +67,56 @@ type CIMDFetcher struct {
 
 // NewCIMDFetcher creates a fetcher with safe defaults.
 func NewCIMDFetcher() *CIMDFetcher {
-	return &CIMDFetcher{
-		HTTPClient: &http.Client{Timeout: cimdFetchTimeout},
-		cache:      make(map[string]cimdCacheEntry),
+	f := &CIMDFetcher{cache: make(map[string]cimdCacheEntry)}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Clone inherits ProxyFromEnvironment. Through a proxy the Control hook
+	// below would only ever see the proxy's own address, never the target,
+	// so the guard would be silently blind. CIMD documents are public
+	// internet resources; fetch them directly.
+	transport.Proxy = nil
+	transport.DialContext = (&net.Dialer{
+		Timeout:   cimdFetchTimeout,
+		KeepAlive: 30 * time.Second,
+		Control:   f.dialControl,
+	}).DialContext
+	f.HTTPClient = &http.Client{Timeout: cimdFetchTimeout, Transport: transport}
+	return f
+}
+
+// dialControl runs after DNS resolution, on the address actually being
+// dialed. That closes the window rejectPrivateHost cannot: a name that
+// resolves public during the pre-flight check and private at connect time
+// (DNS rebinding), and any redirect hop that never went through the check.
+func (f *CIMDFetcher) dialControl(network, address string, c syscall.RawConn) error {
+	if f.AllowPrivateHosts {
+		return nil
 	}
+	return rejectPrivateAddr(network, address, c)
+}
+
+// checkRedirect vets every hop the client is asked to follow. Without it Go
+// follows redirects with no further validation, letting a public host bounce
+// the fetch to an internal one.
+func (f *CIMDFetcher) checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= cimdMaxRedirects {
+		return fmt.Errorf("client metadata fetch exceeded %d redirects", cimdMaxRedirects)
+	}
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("client metadata redirect to non-https URL rejected")
+	}
+	if f.AllowPrivateHosts {
+		return nil
+	}
+	return rejectPrivateHost(req.Context(), req.URL.Hostname())
+}
+
+// clientForFetch returns HTTPClient with the redirect guard installed. It
+// copies rather than mutates so that an injected client (tests) is still
+// guarded without being modified.
+func (f *CIMDFetcher) clientForFetch() *http.Client {
+	c := *f.HTTPClient
+	c.CheckRedirect = f.checkRedirect
+	return &c
 }
 
 // Fetch retrieves and validates the metadata document at clientID.
@@ -98,7 +146,7 @@ func (f *CIMDFetcher) Fetch(ctx context.Context, clientID string) (*ClientInfo, 
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := f.HTTPClient.Do(req)
+	resp, err := f.clientForFetch().Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch client metadata: %w", err)
 	}
@@ -166,6 +214,73 @@ func cacheTTLFromResponse(resp *http.Response) time.Duration {
 	return cimdDefaultTTL
 }
 
+// rejectPrivateAddr fails for a host:port whose IP is not publicly routable.
+// Intended as a net.Dialer.Control hook.
+func rejectPrivateAddr(network, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("malformed dial address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("dial address %q is not a resolved IP", address)
+	}
+	if !isPublicIP(ip) {
+		return fmt.Errorf("client metadata host resolves to a non-public address")
+	}
+	return nil
+}
+
+// nonPublicCIDRs covers ranges that are not publicly routable but that net.IP
+// does not classify: IsPrivate only knows RFC1918 and fc00::/7. Without these,
+// a CGNAT or NAT64 address reaches real infrastructure — 64:ff9b::a9fe:a9fe is
+// the cloud metadata service on any NAT64 network.
+var nonPublicCIDRs = parseCIDRs(
+	"100.64.0.0/10", // RFC 6598 carrier-grade NAT
+	"192.0.0.0/24",  // RFC 6890 IETF protocol assignments
+	"198.18.0.0/15", // RFC 2544 benchmarking
+	"240.0.0.0/4",   // class E, includes 255.255.255.255
+	"64:ff9b::/96",  // RFC 6052 NAT64
+	"64:ff9b:1::/48",
+	"2002::/16",      // 6to4, reaches the embedded IPv4 address
+	"100::/64",       // RFC 6666 discard-only
+	"192.88.99.0/24", // RFC 7526 6to4 relay anycast
+	"2001::/32",      // Teredo, embeds an IPv4 address
+	"2001:10::/28",   // ORCHID
+	"2001:20::/28",   // ORCHIDv2
+	// IPv4-compatible IPv6 (::a.b.c.d). Deprecated by RFC 4291 and normally
+	// unroutable, but To4() only normalizes the ::ffff: form, so ::7f00:1
+	// would otherwise pass every net.IP check as public.
+	"::/96",
+)
+
+func parseCIDRs(cidrs ...string) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic("auth: bad CIDR in nonPublicCIDRs: " + c)
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}
+
+// isPublicIP reports whether ip is publicly routable.
+func isPublicIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() {
+		return false
+	}
+	for _, n := range nonPublicCIDRs {
+		if n.Contains(ip) {
+			return false
+		}
+	}
+	return true
+}
+
 // rejectPrivateHost resolves host and fails if any address is loopback,
 // private, link-local, or otherwise non-global (SSRF guard).
 func rejectPrivateHost(ctx context.Context, host string) error {
@@ -174,8 +289,7 @@ func rejectPrivateHost(ctx context.Context, host string) error {
 		return fmt.Errorf("failed to resolve client metadata host: %w", err)
 	}
 	for _, ip := range ips {
-		if ip.IP.IsLoopback() || ip.IP.IsPrivate() || ip.IP.IsLinkLocalUnicast() ||
-			ip.IP.IsLinkLocalMulticast() || ip.IP.IsUnspecified() {
+		if !isPublicIP(ip.IP) {
 			return fmt.Errorf("client metadata host resolves to a non-public address")
 		}
 	}

--- a/auth/cimd_test.go
+++ b/auth/cimd_test.go
@@ -5,9 +5,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -111,6 +113,142 @@ func TestCIMDFetcher_Fetch_RejectsPrivateHostsByDefault(t *testing.T) {
 		if _, err := fetcher.Fetch(context.Background(), u); err == nil {
 			t.Errorf("expected SSRF rejection for %s", u)
 		}
+	}
+}
+
+// A redirect must not be able to walk the fetch off https onto an internal
+// plain-http endpoint. Asserts the target was never contacted, not merely that
+// Fetch returned some error — an unreachable target would fail either way.
+func TestCIMDFetcher_Fetch_DoesNotFollowRedirectToNonHTTPS(t *testing.T) {
+	var targetHits int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHits++
+		w.Write([]byte("internal"))
+	}))
+	defer target.Close()
+
+	fetcher, u, cleanup := newCIMDTestServer(t, "/client.json", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/latest/meta-data/", http.StatusFound)
+	})
+	defer cleanup()
+
+	_, err := fetcher.Fetch(context.Background(), u)
+	if err == nil {
+		t.Error("expected an error when the metadata document redirects to http")
+	}
+	if targetHits != 0 {
+		t.Errorf("redirect target was contacted %d times, want 0", targetHits)
+	}
+}
+
+// The https case: the redirect stays on https but points at a private address.
+// Exercised directly because the AllowPrivateHosts escape hatch that lets the
+// httptest server (127.0.0.1) be reached at all would also skip this check.
+func TestCIMDFetcher_CheckRedirect_RejectsPrivateHost(t *testing.T) {
+	f := NewCIMDFetcher()
+	req := httptest.NewRequest(http.MethodGet, "https://127.0.0.1/latest/meta-data/", nil)
+
+	if err := f.checkRedirect(req, nil); err == nil {
+		t.Error("expected an https redirect to a loopback address to be rejected")
+	}
+}
+
+func TestCIMDFetcher_CheckRedirect_RejectsTooManyHops(t *testing.T) {
+	f := NewCIMDFetcher()
+	f.AllowPrivateHosts = true
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/next", nil)
+
+	via := make([]*http.Request, cimdMaxRedirects)
+	if err := f.checkRedirect(req, via); err == nil {
+		t.Errorf("expected rejection after %d hops", cimdMaxRedirects)
+	}
+	if err := f.checkRedirect(req, via[:1]); err != nil {
+		t.Errorf("a single hop to a public https host should be allowed, got %v", err)
+	}
+}
+
+// The dial-time guard sees the address actually being connected to, so it
+// covers both redirect targets and DNS rebinding, which rejectPrivateHost
+// (name-based, pre-flight) cannot.
+func TestRejectPrivateAddr(t *testing.T) {
+	tests := []struct {
+		address string
+		wantErr bool
+	}{
+		{"93.184.216.34:443", false}, // public
+		{"[2606:2800:220:1:248:1893:25c8:1946]:443", false},
+		{"127.0.0.1:80", true},
+		{"169.254.169.254:80", true}, // cloud metadata service
+		{"10.0.0.5:443", true},
+		{"192.168.1.1:443", true},
+		{"172.16.0.1:443", true},
+		{"[::1]:443", true},
+		{"[fd00::1]:443", true}, // IPv6 unique-local
+		{"0.0.0.0:80", true},
+		{"[::ffff:127.0.0.1]:80", true}, // IPv4-mapped loopback
+
+		// Ranges net.IP's own helpers do not classify. IsPrivate covers only
+		// RFC1918 and fc00::/7, so these reach real infrastructure otherwise.
+		{"100.64.0.1:80", true},           // RFC 6598 CGNAT (AWS/GCP/k8s NAT)
+		{"[64:ff9b::a9fe:a9fe]:80", true}, // NAT64 of 169.254.169.254
+		{"192.0.0.1:80", true},            // IETF protocol assignments
+		{"198.18.0.1:80", true},           // benchmarking
+		{"240.0.0.1:80", true},            // class E
+		{"255.255.255.255:80", true},      // broadcast
+		{"[2002:7f00:1::]:80", true},      // 6to4 of 127.0.0.1
+		{"224.0.0.1:80", true},            // multicast
+		{"[ff02::1]:80", true},            // link-local multicast
+
+		// IPv4-compatible IPv6 (::a.b.c.d). To4() normalizes only the
+		// ::ffff: form, so no net.IP helper fires on these.
+		{"[::7f00:1]:80", true},    // 127.0.0.1
+		{"[::a9fe:a9fe]:80", true}, // 169.254.169.254
+		{"192.88.99.1:80", true},   // 6to4 relay anycast
+		{"[2001::1]:80", true},     // Teredo
+		{"[2001:10::1]:80", true},  // ORCHID
+	}
+
+	for _, tt := range tests {
+		err := rejectPrivateAddr("tcp", tt.address, nil)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("rejectPrivateAddr(%q) error = %v, wantErr %v", tt.address, err, tt.wantErr)
+		}
+	}
+}
+
+func TestCIMDFetcher_DefaultTransportGuardsDialAddress(t *testing.T) {
+	// Dial a listener that is genuinely accepting connections, so an
+	// unguarded transport would succeed here. Dialling a closed port would
+	// fail with "connection refused" either way and prove nothing.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to open listener: %v", err)
+	}
+	defer ln.Close()
+
+	f := NewCIMDFetcher()
+	tr, ok := f.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("default HTTPClient.Transport is %T, want *http.Transport", f.HTTPClient.Transport)
+	}
+
+	_, err = tr.DialContext(context.Background(), "tcp", ln.Addr().String())
+	if err == nil {
+		t.Fatal("default transport dialled a reachable loopback address; dial guard is not wired")
+	}
+	if !strings.Contains(err.Error(), "non-public address") {
+		t.Errorf("dial failed for the wrong reason: %v", err)
+	}
+}
+
+// An inherited proxy would make the dial guard blind: Control would only ever
+// see the proxy's address, never the real target, silently reinstating the
+// DNS-rebinding bypass.
+func TestCIMDFetcher_DefaultTransportDoesNotUseProxy(t *testing.T) {
+	f := NewCIMDFetcher()
+	tr := f.HTTPClient.Transport.(*http.Transport)
+	if tr.Proxy != nil {
+		t.Error("default transport inherits a proxy, which bypasses the dial guard")
 	}
 }
 


### PR DESCRIPTION
Hi — we run a fork of this project and hit this while reviewing the v1.8.0 CIMD support. Reporting it as a PR rather than an issue since the fix is small and tested; happy to adjust to whatever shape you prefer, or to split it up.

## The problem

`CIMDFetcher.Fetch` server-side-fetches a client-supplied HTTPS URL, and it is reachable unauthenticated through the `client_id` query param of `GET /authorize` (`auth/handlers.go:89-92`):

```
GET /authorize?response_type=code&state=x&client_id=https://attacker.example/cimd.json
```

`rejectPrivateHost` validates only the originally supplied hostname, which leaves two ways around it:

1. **Redirects.** No `CheckRedirect` is set, so Go follows up to 10 hops with no further validation, including an https→http downgrade. The attacker's public host answers `302 Location: http://169.254.169.254/latest/meta-data/`; only the first hop was ever checked.
2. **DNS rebinding.** `rejectPrivateHost`'s `LookupIPAddr` is not the resolution the transport goes on to dial. A low-TTL record answering public-then-private wins the race.

Impact is unauthenticated blind SSRF plus an error oracle (`returned status %d` vs `not valid JSON` distinguishes live internal ports). Response bodies are **not** disclosed — the `doc.ClientID != clientID` check rejects anything that is not a metadata document echoing its own URL — so this is below "read internal data", but it is remotely reachable by anyone.

CodeQL flags the fetch as `go/request-forgery`. That specific alert is not fixable without an allowlist of permitted client hosts, which would contradict the CIMD spec, so this PR hardens the request instead of removing the taint.

## The fix

Guard the address **actually dialled**, with a `net.Dialer.Control` hook. It runs post-resolution on the real peer, so a single check covers both the rebinding race and every redirect hop. Then:

- `checkRedirect` vets each hop for scheme and host, with a 5-hop cap (Go's default is 10).
- `transport.Proxy = nil`. `Transport.Clone()` inherits `ProxyFromEnvironment`, and through a proxy `Control` only ever observes the proxy's own address — the guard would be silently blind, and a loopback sidecar proxy would break every fetch instead. Shout if you have deployments that need proxied egress; this is the one behavioural change here.
- `isPublicIP` gains an explicit deny-CIDR list. `net.IP.IsPrivate()` covers only RFC1918 and `fc00::/7`, so CGNAT (`100.64/10`), NAT64 (`64:ff9b::a9fe:a9fe` is the metadata service on any NAT64 network), 6to4, Teredo, class E and IPv4-compatible IPv6 all passed as public. `To4()` normalizes only the `::ffff:` form, which is why `::a9fe:a9fe` needs the explicit `::/96` entry.
- `clientForFetch()` copies the client rather than mutating it, so the redirect guard applies even when a test injects its own `HTTPClient` — `newCIMDTestServer` replaces it wholesale.

`AllowPrivateHosts` still disables all three checks for tests.

## Verification

`gofmt -l`, `go vet ./...`, `go build ./...` and `go test -race ./...` all clean on `golang:1.25`.

Written test-first. Worth noting: the first draft of two redirect tests passed against a **no-op** implementation — one was really observing a connection error to `169.254.169.254`, the other Go's own hop cap — so they were rewritten to assert the redirect target is never contacted.

Every guard is mutation-tested. Reverting any one of these turns a specific test red:

| Mutation | Killed by |
|---|---|
| drop `Control` from the dialer | `DefaultTransportGuardsDialAddress` |
| re-inherit the env proxy | `DefaultTransportDoesNotUseProxy` |
| drop the deny-CIDR check | `TestRejectPrivateAddr` |
| drop the multicast clauses | `TestRejectPrivateAddr` |
| don't attach `CheckRedirect` | `DoesNotFollowRedirectToNonHTTPS` |
| drop the redirect scheme check | `DoesNotFollowRedirectToNonHTTPS` |
| drop the redirect host check | `CheckRedirect_RejectsPrivateHost` |
| drop the hop cap | `CheckRedirect_RejectsTooManyHops` |

An adversarial review pass also confirmed by execution that `Control` fires for `https://` (`Clone()` leaves `DialTLSContext` nil) and for post-redirect dials, that IPv4-mapped and hex/octal/decimal literal encodings are covered, and that 50 concurrent `Fetch` calls are race-clean.

## One thing not fixed here

`f.cache` has no size bound or eviction, and entries are keyed by the caller-supplied `client_id` with an attacker-influenced TTL (up to 24h via `Cache-Control`). One domain serving valid documents at unlimited paths grows it without limit. Left alone to keep this PR to the SSRF fix — happy to send it separately if you want it.