### PR TITLE
fix(auth): log a token fingerprint instead of a token prefix

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -252,9 +252,7 @@ func unauthorized(w http.ResponseWriter, baseURL, message string) {
 }
 
 // tokenFingerprint returns a short, non-reversible identifier for a token,
-// safe to log for correlating entries about the same token. The previous
-// helper logged the token's first 8 characters — or, for an input shorter
-// than that, the whole thing.
+// safe to log for correlating entries about the same token.
 func tokenFingerprint(token string) string {
 	sum := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(sum[:4])

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -82,7 +84,7 @@ func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, b
 						return
 					}
 				} else {
-					logger.Warn("auth_failed", "reason", "token_not_found", "token_prefix", truncateToken(accessToken))
+					logger.Warn("auth_failed", "reason", "token_not_found", "token_fp", tokenFingerprint(accessToken))
 					unauthorized(w, effectiveURL, "Invalid token")
 					return
 				}
@@ -110,7 +112,7 @@ func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, b
 // It refreshes the Google token and updates the EXISTING token entry in-place,
 // keeping the same access token so the client's bearer token remains valid.
 func tryAutoRefresh(ctx context.Context, store TokenStore, google *GoogleProvider, logger *slog.Logger, accessToken string, baseURL string, accessTokenTTL time.Duration) (*TokenInfo, error) {
-	logger.Info("auth_token_expired", "token_prefix", truncateToken(accessToken), "action", "auto_refresh")
+	logger.Info("auth_token_expired", "token_fp", tokenFingerprint(accessToken), "action", "auto_refresh")
 
 	// Get the expired token info (including refresh token)
 	expiredToken, err := store.GetTokenByAccessIncludeExpired(accessToken)
@@ -249,10 +251,11 @@ func unauthorized(w http.ResponseWriter, baseURL, message string) {
 	json.NewEncoder(w).Encode(resp)
 }
 
-// truncateToken returns the first 8 characters of a token for safe logging.
-func truncateToken(token string) string {
-	if len(token) <= 8 {
-		return token + "..."
-	}
-	return token[:8] + "..."
+// tokenFingerprint returns a short, non-reversible identifier for a token,
+// safe to log for correlating entries about the same token. The previous
+// helper logged the token's first 8 characters — or, for an input shorter
+// than that, the whole thing.
+func tokenFingerprint(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:4])
 }

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -426,24 +428,67 @@ func TestUnauthorized_RetryAfterOnExpired(t *testing.T) {
 	}
 }
 
-func TestTruncateToken(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"abcdefghijklmnop", "abcdefgh..."},
-		{"short", "short..."},
-		{"12345678", "12345678..."},
-		{"123456789", "12345678..."},
-	}
-
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("len=%d", len(tt.input)), func(t *testing.T) {
-			result := truncateToken(tt.input)
-			if result != tt.expected {
-				t.Errorf("truncateToken(%q) = %q, expected %q", tt.input, result, tt.expected)
+func TestTokenFingerprint_LeaksNoTokenBytes(t *testing.T) {
+	for _, token := range []string{
+		"abcdefghijklmnop",
+		"short",
+		"12345678",
+		"aGVsbG8td29ybGQtdGhpcy1pcy1hLXRlc3QtdG9rZW4taGVyZQ",
+	} {
+		t.Run(fmt.Sprintf("len=%d", len(token)), func(t *testing.T) {
+			fp := tokenFingerprint(token)
+			if fp == "" {
+				t.Fatal("fingerprint is empty")
+			}
+			if strings.Contains(fp, token) {
+				t.Errorf("fingerprint %q contains the whole token", fp)
+			}
+			// Any run of token bytes is secret material; the previous helper
+			// logged the first 8, or the entire token when it was shorter.
+			for n := 4; n <= len(token); n++ {
+				if strings.Contains(fp, token[:n]) {
+					t.Errorf("fingerprint %q contains the token prefix %q", fp, token[:n])
+				}
 			}
 		})
+	}
+}
+
+func TestTokenFingerprint_IsStableAndDistinct(t *testing.T) {
+	a := tokenFingerprint("token-one")
+	if a != tokenFingerprint("token-one") {
+		t.Error("fingerprint is not stable, so log lines cannot be correlated")
+	}
+	if a == tokenFingerprint("token-two") {
+		t.Error("distinct tokens share a fingerprint")
+	}
+}
+
+// The alerts behind this are on the log calls, not the helper: a bearer token
+// from the request header must not reach the log in any form.
+func TestMiddleware_AuthFailedLogDoesNotLeakToken(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mw := Middleware(newMockTokenStore(), nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "")
+	handler := mw(dummyHandler)
+
+	const token = "sekrit-bearer-token-value"
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	out := logs.String()
+	if !strings.Contains(out, "auth_failed") {
+		t.Fatalf("expected an auth_failed log line, got: %s", out)
+	}
+	for n := 4; n <= len(token); n++ {
+		if strings.Contains(out, token[:n]) {
+			t.Errorf("log output contains the token prefix %q: %s", token[:n], out)
+		}
+	}
+	if !strings.Contains(out, "token_fp="+tokenFingerprint(token)) {
+		t.Errorf("expected the token fingerprint in the log line, got: %s", out)
 	}
 }
 

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -492,6 +492,43 @@ func TestMiddleware_AuthFailedLogDoesNotLeakToken(t *testing.T) {
 	}
 }
 
+// The auto-refresh path logs the token separately, and is the second of the
+// two lines CodeQL flags.
+func TestMiddleware_ExpiredTokenLogDoesNotLeakToken(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Must share no 4-char run with any word the handler logs (e.g. "expired"
+	// in auth_token_expired), or the leak assertion below false-positives.
+	const token = "zqx-stale-bearer-value"
+	store := newMockTokenStore()
+	store.StoreToken(&TokenInfo{
+		AccessToken: token,
+		ClientID:    "test-client",
+		ExpiresAt:   time.Now().Add(-time.Hour),
+	})
+
+	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "")
+	handler := mw(dummyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	out := logs.String()
+	if !strings.Contains(out, "auth_token_expired") {
+		t.Fatalf("expected an auth_token_expired log line, got: %s", out)
+	}
+	for n := 4; n <= len(token); n++ {
+		if strings.Contains(out, token[:n]) {
+			t.Errorf("log output contains the token prefix %q: %s", token[:n], out)
+		}
+	}
+	if !strings.Contains(out, "token_fp="+tokenFingerprint(token)) {
+		t.Errorf("expected the token fingerprint in the log line, got: %s", out)
+	}
+}
+
 func TestMiddleware_ErrorResponseFormat(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()


### PR DESCRIPTION
Follow-up from our fork review, in the same vein as #70. Small and tested; happy to reshape it.

## The problem

`truncateToken` (`auth/middleware.go:252`) returns the bearer token's first 8 characters — or, when the input is 8 characters or fewer, the **entire token** — and two log calls emit it:

- `auth/middleware.go:85` — `auth_failed`, `token_prefix`
- `auth/middleware.go:113` — `auth_token_expired`, `token_prefix`

CodeQL raises `go/clear-text-logging` on both and does not treat the helper as a sanitizer. That is the right call: a prefix is still secret material sitting in a log, and the short-input branch logs the lot.

Severity is low in practice — a token we issue is `GenerateToken(32)` → 44 base64 chars, so only ~48 of 256 bits reach the log, and the short branch only triggers on a value that was never one of our tokens. It is still worth not writing.

## The fix

`tokenFingerprint` returns the first 4 bytes of the token's SHA-256, hex-encoded. No token bytes reach the log, and lines about the same token still correlate. Log key `token_prefix` → `token_fp`.

On the 32-bit width: tokens carry 256 bits of entropy, so a 32-bit digest is not brute-forceable back to a token, and an unsalted hash only lets someone who already holds a token confirm it appeared in the log. Collisions follow the birthday bound — ~50% chance of one colliding pair across ~77k distinct tokens — and the only consequence is a rare false correlation between log lines, never an auth decision.

Confirmed against a real scan rather than assumed: CodeQL reports **zero** open `go/clear-text-logging` alerts on this branch, both still open on `main`.

## Verification

Written test-first. Both new tests were run against a `tokenFingerprint` still delegating to `truncateToken` and failed on exactly the leaked prefixes.

| Mutation | Killed by |
|---|---|
| revert `middleware.go:85` to a prefix log | `TestMiddleware_AuthFailedLogDoesNotLeakToken` |
| revert `middleware.go:113` to a prefix log | `TestMiddleware_ExpiredTokenLogDoesNotLeakToken` |
| return the token prefix from `tokenFingerprint` | `TestTokenFingerprint_LeaksNoTokenBytes` |

The two middleware tests assert on real `slog` output through the real `Middleware`, not on the helper. A review pass caught that the second flagged line had no assertion at first — reverting it alone left the suite green — hence the second test.

`gofmt -l`, `go vet ./...`, `go build ./...` and `go test -race ./...` clean on `golang:1.25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPxpAxX3rX4wNYPLzCUsVn