### PR TITLE
fix(auth): bound the CIMD metadata cache and reclaim expired entries

### DIFF
--- a/auth/cimd.go
+++ b/auth/cimd.go
@@ -199,10 +199,12 @@ func (f *CIMDFetcher) Fetch(ctx context.Context, clientID string) (*ClientInfo, 
 
 // storeInCache inserts an entry, first dropping every expired entry (lookup
 // only skips them, so otherwise nothing is ever reclaimed) and then evicting
-// until there is room. Eviction relies on Go's randomized map order rather
-// than on expiry: TTLs are caller-influenced via Cache-Control, so evicting
-// the soonest-to-expire would let a flood of long-TTL entries preferentially
-// push out legitimate short-TTL ones.
+// until there is room. The victim comes from Go's unspecified, runtime-
+// randomized map iteration order rather than from expiry order: TTLs are
+// caller-influenced via Cache-Control, so evicting the soonest-to-expire
+// would let a flood of long-TTL entries preferentially push out legitimate
+// short-TTL ones. The property relied on is that a caller cannot predict or
+// bias the victim, not that the choice is uniform.
 func (f *CIMDFetcher) storeInCache(clientID string, entry cimdCacheEntry) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/auth/cimd.go
+++ b/auth/cimd.go
@@ -25,6 +25,10 @@ const (
 	cimdDefaultTTL   = 5 * time.Minute
 	cimdMaxTTL       = 24 * time.Hour
 	cimdMaxRedirects = 5
+	// cimdMaxCacheEntries bounds the cache. /authorize is unauthenticated and
+	// entries are keyed by the caller-supplied client_id, so without a cap one
+	// domain serving valid documents at unlimited paths grows it without limit.
+	cimdMaxCacheEntries = 256
 )
 
 // IsClientIDMetadataURL reports whether clientID is a valid CIMD identifier:
@@ -188,11 +192,35 @@ func (f *CIMDFetcher) Fetch(ctx context.Context, clientID string) (*ClientInfo, 
 	}
 
 	ttl := cacheTTLFromResponse(resp)
-	f.mu.Lock()
-	f.cache[clientID] = cimdCacheEntry{client: client, expiresAt: time.Now().Add(ttl)}
-	f.mu.Unlock()
+	f.storeInCache(clientID, cimdCacheEntry{client: client, expiresAt: time.Now().Add(ttl)})
 
 	return client, nil
+}
+
+// storeInCache inserts an entry, first dropping every expired entry (lookup
+// only skips them, so otherwise nothing is ever reclaimed) and then evicting
+// until there is room. Eviction relies on Go's randomized map order rather
+// than on expiry: TTLs are caller-influenced via Cache-Control, so evicting
+// the soonest-to-expire would let a flood of long-TTL entries preferentially
+// push out legitimate short-TTL ones.
+func (f *CIMDFetcher) storeInCache(clientID string, entry cimdCacheEntry) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	now := time.Now()
+	for k, e := range f.cache {
+		if !now.Before(e.expiresAt) {
+			delete(f.cache, k)
+		}
+	}
+	for k := range f.cache {
+		if len(f.cache) < cimdMaxCacheEntries {
+			break
+		}
+		delete(f.cache, k)
+	}
+
+	f.cache[clientID] = entry
 }
 
 // cacheTTLFromResponse derives a bounded cache TTL from Cache-Control max-age.

--- a/auth/cimd_test.go
+++ b/auth/cimd_test.go
@@ -275,7 +275,7 @@ func TestCIMDFetcher_Fetch_Caches(t *testing.T) {
 
 // newCIMDPathServer serves a valid metadata document at every path, each
 // echoing its own URL, so a single server can back many distinct client_ids.
-func newCIMDPathServer(t *testing.T) (*CIMDFetcher, string, func()) {
+func newCIMDPathServer(t *testing.T) (*CIMDFetcher, string) {
 	t.Helper()
 	var base string
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -283,15 +283,15 @@ func newCIMDPathServer(t *testing.T) (*CIMDFetcher, string, func()) {
 		fmt.Fprintf(w, `{"client_id": %q, "client_name": "x", "redirect_uris": ["http://localhost:3000/cb"]}`, base+r.URL.Path)
 	}))
 	base = ts.URL
+	t.Cleanup(ts.Close)
 	fetcher := NewCIMDFetcher()
 	fetcher.HTTPClient = ts.Client()
 	fetcher.AllowPrivateHosts = true // httptest listens on 127.0.0.1
-	return fetcher, ts.URL, ts.Close
+	return fetcher, ts.URL
 }
 
 func TestCIMDFetcher_Cache_BoundedByMaxEntries(t *testing.T) {
-	fetcher, base, cleanup := newCIMDPathServer(t)
-	defer cleanup()
+	fetcher, base := newCIMDPathServer(t)
 
 	for i := 0; i < cimdMaxCacheEntries+10; i++ {
 		u := fmt.Sprintf("%s/client-%d.json", base, i)
@@ -306,11 +306,15 @@ func TestCIMDFetcher_Cache_BoundedByMaxEntries(t *testing.T) {
 	if size > cimdMaxCacheEntries {
 		t.Errorf("cache holds %d entries, want at most %d", size, cimdMaxCacheEntries)
 	}
+	// Without a lower bound, clearing the whole cache on every insert would
+	// pass the check above while making the cache useless.
+	if size < cimdMaxCacheEntries/2 {
+		t.Errorf("cache holds only %d entries after overflow, evicting far more than needed", size)
+	}
 }
 
 func TestCIMDFetcher_Cache_DropsExpiredEntriesOnInsert(t *testing.T) {
-	fetcher, base, cleanup := newCIMDPathServer(t)
-	defer cleanup()
+	fetcher, base := newCIMDPathServer(t)
 
 	fetcher.mu.Lock()
 	fetcher.cache["https://stale.example.com/client.json"] = cimdCacheEntry{

--- a/auth/cimd_test.go
+++ b/auth/cimd_test.go
@@ -273,6 +273,64 @@ func TestCIMDFetcher_Fetch_Caches(t *testing.T) {
 	}
 }
 
+// newCIMDPathServer serves a valid metadata document at every path, each
+// echoing its own URL, so a single server can back many distinct client_ids.
+func newCIMDPathServer(t *testing.T) (*CIMDFetcher, string, func()) {
+	t.Helper()
+	var base string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"client_id": %q, "client_name": "x", "redirect_uris": ["http://localhost:3000/cb"]}`, base+r.URL.Path)
+	}))
+	base = ts.URL
+	fetcher := NewCIMDFetcher()
+	fetcher.HTTPClient = ts.Client()
+	fetcher.AllowPrivateHosts = true // httptest listens on 127.0.0.1
+	return fetcher, ts.URL, ts.Close
+}
+
+func TestCIMDFetcher_Cache_BoundedByMaxEntries(t *testing.T) {
+	fetcher, base, cleanup := newCIMDPathServer(t)
+	defer cleanup()
+
+	for i := 0; i < cimdMaxCacheEntries+10; i++ {
+		u := fmt.Sprintf("%s/client-%d.json", base, i)
+		if _, err := fetcher.Fetch(context.Background(), u); err != nil {
+			t.Fatalf("fetch %d failed: %v", i, err)
+		}
+	}
+
+	fetcher.mu.Lock()
+	size := len(fetcher.cache)
+	fetcher.mu.Unlock()
+	if size > cimdMaxCacheEntries {
+		t.Errorf("cache holds %d entries, want at most %d", size, cimdMaxCacheEntries)
+	}
+}
+
+func TestCIMDFetcher_Cache_DropsExpiredEntriesOnInsert(t *testing.T) {
+	fetcher, base, cleanup := newCIMDPathServer(t)
+	defer cleanup()
+
+	fetcher.mu.Lock()
+	fetcher.cache["https://stale.example.com/client.json"] = cimdCacheEntry{
+		client:    &ClientInfo{ClientID: "https://stale.example.com/client.json"},
+		expiresAt: time.Now().Add(-time.Minute),
+	}
+	fetcher.mu.Unlock()
+
+	if _, err := fetcher.Fetch(context.Background(), base+"/client.json"); err != nil {
+		t.Fatalf("fetch failed: %v", err)
+	}
+
+	fetcher.mu.Lock()
+	_, stillCached := fetcher.cache["https://stale.example.com/client.json"]
+	fetcher.mu.Unlock()
+	if stillCached {
+		t.Error("expired entry survived an insert, so memory is never reclaimed")
+	}
+}
+
 const testTTL = 1 * time.Hour
 
 // doAuthorize performs a GET /authorize with valid PKCE params.


### PR DESCRIPTION
This is the cache issue flagged at the end of #70, sent separately as offered.

## The problem

`CIMDFetcher.cache` (`auth/cimd.go:65`) has no size bound and no eviction. `/authorize` is unauthenticated and entries are keyed by the caller-supplied `client_id`, so one domain serving valid metadata documents at unlimited distinct paths grows the map without limit — each entry pinned for a TTL the same caller chooses via `Cache-Control` (up to `cimdMaxTTL`, 24h). Lookup skips expired entries but never deletes them, so memory is never reclaimed even after everything has expired.

Per-entry size is already bounded by `cimdMaxBodyBytes`, so this is entry count, not entry size — sustained requests for memory pressure, nothing like the severity of #70.

## The fix

Inserts go through `storeInCache`, which under the existing mutex drops every expired entry, then evicts until there is room, then inserts. Cap is 256 entries.

The victim comes from Go's unspecified, runtime-randomized map iteration order rather than from expiry order. Expiry order looks tidier but is wrong here: TTLs are caller-influenced, so a flood of `max-age=86400` entries would preferentially push out legitimate 5-minute ones. The property being relied on is that a caller cannot predict or bias the victim, not that the choice is uniform.

The residual attack — flood 256 client_ids to evict a legitimate client's entry — costs that client one re-fetch, bounded by the existing 10s timeout and 64 KiB cap. Strictly better than unbounded growth.

Not addressed here: concurrent misses for the same `client_id` still fetch in parallel with last-write-wins (no singleflight). Pre-existing and harmless — same document either way — so it stayed out of this PR.

## Verification

Written test-first, both tests observed failing against the unbounded cache (`266 entries, want at most 256`; `expired entry survived an insert`).

| Mutation | Killed by |
|---|---|
| drop the eviction loop | `Cache_BoundedByMaxEntries` (upper bound) |
| clear the whole map on insert instead of evicting | `Cache_BoundedByMaxEntries` (lower bound) |
| drop the expired-entry purge | `Cache_DropsExpiredEntriesOnInsert` |

The lower bound exists because a review pass found that `f.cache = make(...)` on every insert passed the suite — the cache would have been silently useless while every test stayed green.

`gofmt -l`, `go vet ./...`, `go build ./...` and `go test -race ./...` clean on `golang:1.25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPxpAxX3rX4wNYPLzCUsVn