### PR TITLE
fix(auth): keep tokens whose refresh window is still open

### DIFF
--- a/auth/cleanup_test.go
+++ b/auth/cleanup_test.go
@@ -1,0 +1,72 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// A token whose access has expired but whose refresh token is still valid must
+// survive cleanup: the refresh token can still mint new access tokens, so
+// purging it forces a needless re-authentication. This is the root cause of the
+// "re-authenticate several times a day" bug.
+func TestMemoryTokenStore_Cleanup_KeepsTokenWithValidRefresh(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	now := time.Now()
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "access-1",
+		RefreshToken:     "refresh-1",
+		ExpiresAt:        now.Add(-2 * time.Hour),      // access expired well past the +1h grace
+		RefreshExpiresAt: now.Add(29 * 24 * time.Hour), // refresh still valid for ~29 days
+		CreatedAt:        now.Add(-10 * time.Hour),
+	})
+
+	store.purgeExpired(now)
+
+	if _, err := store.GetTokenByRefresh("refresh-1"); err != nil {
+		t.Fatalf("token with valid refresh window was purged: %v", err)
+	}
+}
+
+// Once the refresh window has lapsed the token is dead weight and must be removed.
+func TestMemoryTokenStore_Cleanup_RemovesTokenWithExpiredRefresh(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	now := time.Now()
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "access-2",
+		RefreshToken:     "refresh-2",
+		ExpiresAt:        now.Add(-31 * 24 * time.Hour),
+		RefreshExpiresAt: now.Add(-1 * time.Hour), // refresh window lapsed
+		CreatedAt:        now.Add(-31 * 24 * time.Hour),
+	})
+
+	store.purgeExpired(now)
+
+	if _, err := store.GetTokenByRefresh("refresh-2"); err != ErrTokenNotFound {
+		t.Errorf("expected expired-refresh token to be purged, got %v", err)
+	}
+}
+
+// Short-lived auth-code tokens have no refresh token; they must still be purged
+// once their (short) access expiry has lapsed, so they don't leak forever.
+func TestMemoryTokenStore_Cleanup_RemovesExpiredAuthCodeToken(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	now := time.Now()
+	store.StoreToken(&TokenInfo{
+		AccessToken: "code-token",
+		// no RefreshToken, no RefreshExpiresAt — like the temporary auth-code token
+		ExpiresAt: now.Add(-2 * time.Hour),
+		CreatedAt: now.Add(-2 * time.Hour),
+	})
+
+	store.purgeExpired(now)
+
+	if _, err := store.GetTokenByAccessIncludeExpired("code-token"); err != ErrTokenNotFound {
+		t.Errorf("expected expired auth-code token to be purged, got %v", err)
+	}
+}

--- a/auth/cleanup_test.go
+++ b/auth/cleanup_test.go
@@ -70,3 +70,49 @@ func TestMemoryTokenStore_Cleanup_RemovesExpiredAuthCodeToken(t *testing.T) {
 		t.Errorf("expected expired auth-code token to be purged, got %v", err)
 	}
 }
+
+// An entry carrying a refresh token but no recorded refresh window has no
+// expiry to check against, so treating it as refreshable would keep it — and
+// keep it resolvable through GetTokenByRefresh — for the process lifetime. No
+// current caller stores that shape; the guard is for the next one.
+func TestMemoryTokenStore_Cleanup_RemovesTokenWithNoRefreshWindow(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	now := time.Now()
+	store.StoreToken(&TokenInfo{
+		AccessToken:  "access-3",
+		RefreshToken: "refresh-3",
+		ExpiresAt:    now.Add(-2 * time.Hour),
+		// RefreshExpiresAt deliberately left zero
+		CreatedAt: now.Add(-10 * time.Hour),
+	})
+
+	store.purgeExpired(now)
+
+	if _, err := store.GetTokenByRefresh("refresh-3"); err != ErrTokenNotFound {
+		t.Errorf("expected token with no refresh window to be purged, got %v", err)
+	}
+}
+
+// The access token stays usable until its own expiry, so an entry whose
+// refresh window has lapsed must not be yanked out from under a live session.
+func TestMemoryTokenStore_Cleanup_KeepsLiveAccessAfterRefreshLapses(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	now := time.Now()
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "access-4",
+		RefreshToken:     "refresh-4",
+		ExpiresAt:        now.Add(1 * time.Hour),  // still valid
+		RefreshExpiresAt: now.Add(-1 * time.Hour), // refresh window lapsed
+		CreatedAt:        now.Add(-30 * 24 * time.Hour),
+	})
+
+	store.purgeExpired(now)
+
+	if _, err := store.GetTokenByAccess("access-4"); err != nil {
+		t.Errorf("live access token was purged with its lapsed refresh window: %v", err)
+	}
+}

--- a/auth/token_store.go
+++ b/auth/token_store.go
@@ -315,49 +315,57 @@ func (s *MemoryTokenStore) cleanup(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
-	const maxClients = 1000
-
 	for {
 		select {
 		case <-ticker.C:
-			now := time.Now()
-
-			// Delete directly under write lock to avoid race conditions
-			// between collecting expired keys and deleting them.
-			s.mu.Lock()
-			for accessToken, info := range s.tokens {
-				accessExpired := now.After(info.ExpiresAt.Add(1 * time.Hour))
-				refreshExpired := !info.RefreshExpiresAt.IsZero() && now.After(info.RefreshExpiresAt)
-				if accessExpired || refreshExpired {
-					delete(s.refreshIndex, info.RefreshToken)
-					delete(s.tokens, accessToken)
-				}
-			}
-			for stateValue, state := range s.states {
-				if now.Sub(state.CreatedAt) > 10*time.Minute {
-					delete(s.states, stateValue)
-				}
-			}
-			// Evict oldest clients until back under limit
-			for len(s.clients) > maxClients {
-				var oldest string
-				var oldestTime time.Time
-				for id, client := range s.clients {
-					if oldest == "" || client.CreatedAt.Before(oldestTime) {
-						oldest = id
-						oldestTime = client.CreatedAt
-					}
-				}
-				if oldest != "" {
-					delete(s.clients, oldest)
-				} else {
-					break
-				}
-			}
-			s.mu.Unlock()
+			s.purgeExpired(time.Now())
 
 		case <-ctx.Done():
 			return
+		}
+	}
+}
+
+// purgeExpired removes expired tokens and states, and evicts stale clients.
+// It runs under the write lock to avoid races between collecting and deleting.
+func (s *MemoryTokenStore) purgeExpired(now time.Time) {
+	const maxClients = 1000
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for accessToken, info := range s.tokens {
+		accessExpired := now.After(info.ExpiresAt.Add(1 * time.Hour))
+		refreshExpired := !info.RefreshExpiresAt.IsZero() && now.After(info.RefreshExpiresAt)
+		// A token whose refresh token is still valid can mint new access
+		// tokens, so keep it — purging on access expiry alone would force a
+		// needless re-authentication. Drop a token only once its refresh
+		// window has lapsed, or (for short-lived auth-code tokens that have no
+		// refresh token) once its access has expired.
+		if refreshExpired || (accessExpired && info.RefreshToken == "") {
+			delete(s.refreshIndex, info.RefreshToken)
+			delete(s.tokens, accessToken)
+		}
+	}
+	for stateValue, state := range s.states {
+		if now.Sub(state.CreatedAt) > 10*time.Minute {
+			delete(s.states, stateValue)
+		}
+	}
+	// Evict oldest clients until back under limit
+	for len(s.clients) > maxClients {
+		var oldest string
+		var oldestTime time.Time
+		for id, client := range s.clients {
+			if oldest == "" || client.CreatedAt.Before(oldestTime) {
+				oldest = id
+				oldestTime = client.CreatedAt
+			}
+		}
+		if oldest != "" {
+			delete(s.clients, oldest)
+		} else {
+			break
 		}
 	}
 }

--- a/auth/token_store.go
+++ b/auth/token_store.go
@@ -336,13 +336,16 @@ func (s *MemoryTokenStore) purgeExpired(now time.Time) {
 
 	for accessToken, info := range s.tokens {
 		accessExpired := now.After(info.ExpiresAt.Add(1 * time.Hour))
-		refreshExpired := !info.RefreshExpiresAt.IsZero() && now.After(info.RefreshExpiresAt)
-		// A token whose refresh token is still valid can mint new access
+		// A token whose refresh window is still open can mint new access
 		// tokens, so keep it — purging on access expiry alone would force a
-		// needless re-authentication. Drop a token only once its refresh
-		// window has lapsed, or (for short-lived auth-code tokens that have no
-		// refresh token) once its access has expired.
-		if refreshExpired || (accessExpired && info.RefreshToken == "") {
+		// needless re-authentication. An entry with a refresh token but no
+		// recorded window counts as not refreshable rather than as refreshable
+		// forever, so a caller that forgets the field cannot pin an entry here
+		// for the process lifetime.
+		refreshable := info.RefreshToken != "" &&
+			!info.RefreshExpiresAt.IsZero() &&
+			now.Before(info.RefreshExpiresAt)
+		if accessExpired && !refreshable {
 			delete(s.refreshIndex, info.RefreshToken)
 			delete(s.tokens, accessToken)
 		}


### PR DESCRIPTION
The first half of the persistence work offered on #74. Standalone — it does not depend on the file store PR.

## The bug

Cleanup deleted any entry whose access token had expired an hour ago, even when its refresh token was still valid for another 29 days. `tryAutoRefresh` needs exactly that entry, so instead of a silent refresh the client was pushed back through the full OAuth flow. This is the root cause of the repeated re-authentication.

An entry is now dropped once its refresh window has lapsed, or — for the short-lived auth-code token, which carries no refresh token — once its access has expired. A lapsed refresh window no longer yanks an access token that is still inside its own expiry.

The cleanup body moves into `purgeExpired` so tests can drive it directly instead of waiting on the five-minute ticker.

## Security tradeoff, stated explicitly

This lengthens the window in which a leaked bearer is useful. `tryAutoRefresh` accepts an *expired* access token and extends the same bearer via `ExtendTokenExpiry` without rotating it, so before this change a bearer captured from a log or proxy was dead roughly an hour after its expiry. Now it stays usable until `RefreshExpiresAt` — up to 30 days — because the entry it resolves to is still there.

That is inherent to fixing the re-auth loop: keeping the entry alive is the whole point. But it means access-token expiry no longer bounds a leaked bearer, and the bearer becomes roughly equivalent in value to the refresh token, without the rotation the explicit refresh grant does at `handlers.go:488`. Rotating the bearer inside `tryAutoRefresh` would bound it again; that is a client-visible change, so it is not folded into this PR.

The new `refreshable` predicate carries one guard: an entry with a refresh token but a zero `RefreshExpiresAt` counts as not refreshable, so a missing window purges on access expiry rather than being read as "refreshable forever" and pinning the entry for the process lifetime. No caller in the tree stores that shape, but the exported `StoreToken` makes it reachable.

`gofmt -l`, `go vet`, `go build`, `go test -race ./...` clean.
