### PR TITLE
feat(auth): optional file-backed token store to survive restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN apk add --no-cache ca-certificates tzdata
 # Copy binary from builder
 COPY --from=builder /app/gtm-mcp-server .
 
-# Create non-root user
-RUN adduser -D -g '' appuser
+# Create non-root user and a writable data directory for TOKEN_STORE_PATH
+RUN adduser -D -g '' appuser && mkdir -p /data && chown appuser:appuser /data && chmod 700 /data
 USER appuser
 
 # Expose port

--- a/README.md
+++ b/README.md
@@ -369,6 +369,16 @@ ALLOWED_HOSTS=gtm-mcp:8080
 
 This enables dynamic URL resolution for trusted internal hostnames while keeping the server secure against host header injection.
 
+#### Token Persistence (TOKEN_STORE_PATH)
+
+By default, issued tokens are kept in memory only, so **every restart logs all users out** and forces them to re-authenticate. To keep sessions across restarts, point `TOKEN_STORE_PATH` at a file on a persistent volume:
+
+```bash
+TOKEN_STORE_PATH=/data/tokens.json
+```
+
+The file is written with `0600` permissions and holds refresh tokens, so it belongs on a volume you would treat as secret. Leave `TOKEN_STORE_PATH` unset to keep the in-memory behaviour.
+
 ### Google Cloud Setup
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ By default, issued tokens are kept in memory only, so **every restart logs all u
 TOKEN_STORE_PATH=/data/tokens.json
 ```
 
-The file is written with `0600` permissions and holds refresh tokens, so it belongs on a volume you would treat as secret. Leave `TOKEN_STORE_PATH` unset to keep the in-memory behaviour.
+The file is written with `0600` permissions and holds refresh tokens, so it belongs on a volume you would treat as secret. The directory must be writable by the user the server runs as (the Docker image runs as `appuser` and ships `/data` owned by it, mode `0700`; a directory the server creates itself gets the same mode) — the store fails closed, so a path that cannot be created or read stops the server at startup rather than silently discarding sessions. Leave `TOKEN_STORE_PATH` unset to keep the in-memory behaviour.
 
 ### Google Cloud Setup
 

--- a/auth/file_token_store.go
+++ b/auth/file_token_store.go
@@ -1,0 +1,180 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// FileTokenStore is a TokenStore that persists issued tokens to a JSON file so
+// that sessions survive process restarts (container redeploys, crashes, host
+// reboots). It embeds MemoryTokenStore for all in-memory behaviour and writes a
+// snapshot to disk after every token mutation.
+//
+// Only issued tokens are persisted. OAuth flow states (10-minute lifetime) and
+// dynamically-registered clients are intentionally not persisted: they are
+// short-lived or re-created by the client on reconnect, and a valid bearer
+// token alone is enough to keep a user authenticated across a restart.
+type FileTokenStore struct {
+	*MemoryTokenStore
+
+	path   string
+	logger *slog.Logger
+	saveMu sync.Mutex // serialises writes to the file
+}
+
+// persistedState is the on-disk shape of the store.
+type persistedState struct {
+	Tokens []*TokenInfo `json:"tokens"`
+}
+
+// NewFileTokenStore creates a file-backed token store, loading any existing
+// tokens from path. A missing file is treated as an empty store (first run).
+func NewFileTokenStore(path string, logger *slog.Logger) (*FileTokenStore, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create token store directory: %w", err)
+	}
+
+	f := &FileTokenStore{
+		MemoryTokenStore: NewMemoryTokenStore(),
+		path:             path,
+		logger:           logger,
+	}
+
+	if err := f.load(); err != nil {
+		return nil, fmt.Errorf("failed to load token store from %s: %w", path, err)
+	}
+
+	return f, nil
+}
+
+// StoreToken persists after delegating to the in-memory store.
+func (f *FileTokenStore) StoreToken(info *TokenInfo) error {
+	if err := f.MemoryTokenStore.StoreToken(info); err != nil {
+		return err
+	}
+	f.persist()
+	return nil
+}
+
+// DeleteToken persists after delegating to the in-memory store.
+func (f *FileTokenStore) DeleteToken(accessToken string) error {
+	if err := f.MemoryTokenStore.DeleteToken(accessToken); err != nil {
+		return err
+	}
+	f.persist()
+	return nil
+}
+
+// UpdateGoogleToken persists after delegating to the in-memory store.
+func (f *FileTokenStore) UpdateGoogleToken(accessToken string, googleToken *oauth2.Token) error {
+	if err := f.MemoryTokenStore.UpdateGoogleToken(accessToken, googleToken); err != nil {
+		return err
+	}
+	f.persist()
+	return nil
+}
+
+// ExtendTokenExpiry persists after delegating to the in-memory store.
+func (f *FileTokenStore) ExtendTokenExpiry(accessToken string, newExpiry time.Time) error {
+	if err := f.MemoryTokenStore.ExtendTokenExpiry(accessToken, newExpiry); err != nil {
+		return err
+	}
+	f.persist()
+	return nil
+}
+
+// load reads tokens from disk into the in-memory maps. Tokens whose refresh
+// window has already lapsed are skipped — they cannot be refreshed anyway.
+func (f *FileTokenStore) load() error {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // first run, nothing to load
+		}
+		return err
+	}
+
+	var state persistedState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	f.MemoryTokenStore.mu.Lock()
+	defer f.MemoryTokenStore.mu.Unlock()
+
+	loaded := 0
+	for _, info := range state.Tokens {
+		if info == nil || info.AccessToken == "" {
+			continue
+		}
+		if !info.RefreshExpiresAt.IsZero() && now.After(info.RefreshExpiresAt) {
+			continue
+		}
+		f.MemoryTokenStore.tokens[info.AccessToken] = info
+		if info.RefreshToken != "" {
+			f.MemoryTokenStore.refreshIndex[info.RefreshToken] = info.AccessToken
+		}
+		loaded++
+	}
+
+	if f.logger != nil {
+		f.logger.Info("loaded persisted tokens", "count", loaded, "path", f.path)
+	}
+	return nil
+}
+
+// persist writes a snapshot of the current tokens to disk. It is best-effort:
+// a write failure is logged but does not fail the originating request, since
+// the in-memory state is still correct for the running process.
+func (f *FileTokenStore) persist() {
+	f.saveMu.Lock()
+	defer f.saveMu.Unlock()
+
+	state := persistedState{Tokens: f.snapshot()}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		if f.logger != nil {
+			f.logger.Warn("failed to marshal token store", "error", err)
+		}
+		return
+	}
+
+	// Atomic write: write to a temp file then rename, so a crash mid-write
+	// cannot corrupt the existing file.
+	tmp := f.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		if f.logger != nil {
+			f.logger.Warn("failed to write token store", "error", err, "path", tmp)
+		}
+		return
+	}
+	if err := os.Rename(tmp, f.path); err != nil {
+		if f.logger != nil {
+			f.logger.Warn("failed to rename token store", "error", err, "path", f.path)
+		}
+	}
+}
+
+// snapshot returns the current tokens under the read lock. Holding the lock for
+// the duration of the copy prevents a concurrent-map-iteration panic against
+// writers; marshalling happens after the lock is released in persist.
+func (f *FileTokenStore) snapshot() []*TokenInfo {
+	f.MemoryTokenStore.mu.RLock()
+	defer f.MemoryTokenStore.mu.RUnlock()
+
+	out := make([]*TokenInfo, 0, len(f.MemoryTokenStore.tokens))
+	for _, info := range f.MemoryTokenStore.tokens {
+		out = append(out, info)
+	}
+	return out
+}

--- a/auth/file_token_store.go
+++ b/auth/file_token_store.go
@@ -15,7 +15,11 @@ import (
 // FileTokenStore is a TokenStore that persists issued tokens to a JSON file so
 // that sessions survive process restarts (container redeploys, crashes, host
 // reboots). It embeds MemoryTokenStore for all in-memory behaviour and writes a
-// snapshot to disk after every token mutation.
+// snapshot to disk after every token mutation. The embedded store's background
+// purge does not trigger a write, so the file can hold purged entries until the
+// next mutation rewrites it; that is deliberate — load skips entries with a
+// lapsed refresh window, and a reloaded auth-code token is rejected on lookup,
+// so the lag has no security consequence.
 //
 // Only issued tokens are persisted. OAuth flow states (10-minute lifetime) and
 // dynamically-registered clients are intentionally not persisted: they are
@@ -198,11 +202,15 @@ func (f *FileTokenStore) persistBestEffort() {
 	}
 }
 
-// snapshot returns a copy of the current tokens under the read lock. The
-// entries must be cloned, not aliased: marshalling happens after the lock is
-// released, while ExtendTokenExpiry and UpdateGoogleToken mutate the stored
-// structs in place, so sharing the pointers would race and could serialise a
-// torn ExpiresAt as the authoritative expiry.
+// snapshot returns a copy of the current tokens under the read lock.
+// cloneTokenInfo is a shallow copy: value fields such as ExpiresAt are copied
+// under the lock, which is what keeps marshalling outside the lock safe while
+// ExtendTokenExpiry mutates them in place — aliasing the structs would race
+// and could serialise a torn ExpiresAt as the authoritative expiry. The
+// GoogleToken pointer is still shared with the live entry; that is safe only
+// because UpdateGoogleToken swaps in a new pointer rather than writing through
+// the old one, so an in-place mutation of a stored *oauth2.Token anywhere in
+// the store would reintroduce the race.
 func (f *FileTokenStore) snapshot() []*TokenInfo {
 	f.MemoryTokenStore.mu.RLock()
 	defer f.MemoryTokenStore.mu.RUnlock()

--- a/auth/file_token_store.go
+++ b/auth/file_token_store.go
@@ -59,7 +59,7 @@ func (f *FileTokenStore) StoreToken(info *TokenInfo) error {
 	if err := f.MemoryTokenStore.StoreToken(info); err != nil {
 		return err
 	}
-	f.persist()
+	f.persistBestEffort()
 	return nil
 }
 
@@ -68,7 +68,14 @@ func (f *FileTokenStore) DeleteToken(accessToken string) error {
 	if err := f.MemoryTokenStore.DeleteToken(accessToken); err != nil {
 		return err
 	}
-	f.persist()
+	// A revoked token that stays on disk is valid again after a restart, so
+	// this is the one path where a persist failure must reach the caller.
+	if err := f.persist(); err != nil {
+		if f.logger != nil {
+			f.logger.Error("failed to persist token revocation", "error", err, "path", f.path)
+		}
+		return err
+	}
 	return nil
 }
 
@@ -77,7 +84,7 @@ func (f *FileTokenStore) UpdateGoogleToken(accessToken string, googleToken *oaut
 	if err := f.MemoryTokenStore.UpdateGoogleToken(accessToken, googleToken); err != nil {
 		return err
 	}
-	f.persist()
+	f.persistBestEffort()
 	return nil
 }
 
@@ -86,7 +93,7 @@ func (f *FileTokenStore) ExtendTokenExpiry(accessToken string, newExpiry time.Ti
 	if err := f.MemoryTokenStore.ExtendTokenExpiry(accessToken, newExpiry); err != nil {
 		return err
 	}
-	f.persist()
+	f.persistBestEffort()
 	return nil
 }
 
@@ -132,10 +139,12 @@ func (f *FileTokenStore) load() error {
 	return nil
 }
 
-// persist writes a snapshot of the current tokens to disk. It is best-effort:
-// a write failure is logged but does not fail the originating request, since
-// the in-memory state is still correct for the running process.
-func (f *FileTokenStore) persist() {
+// persist writes a snapshot of the current tokens to disk, returning the first
+// error it hits. Callers that only add or update state treat it as best-effort
+// — the in-memory state is still correct for the running process — but a
+// revocation that is not on disk would come back to life on restart, so
+// DeleteToken surfaces the failure.
+func (f *FileTokenStore) persist() error {
 	f.saveMu.Lock()
 	defer f.saveMu.Unlock()
 
@@ -143,38 +152,64 @@ func (f *FileTokenStore) persist() {
 
 	data, err := json.Marshal(state)
 	if err != nil {
-		if f.logger != nil {
-			f.logger.Warn("failed to marshal token store", "error", err)
-		}
-		return
+		return fmt.Errorf("failed to marshal token store: %w", err)
 	}
 
 	// Atomic write: write to a temp file then rename, so a crash mid-write
-	// cannot corrupt the existing file.
-	tmp := f.path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		if f.logger != nil {
-			f.logger.Warn("failed to write token store", "error", err, "path", tmp)
-		}
-		return
+	// cannot corrupt the existing file. The temp file is created exclusively
+	// with a random name rather than reusing a predictable path: os.WriteFile
+	// follows symlinks, so a pre-planted <path>.tmp link would siphon every
+	// refresh token to a location of the attacker's choosing.
+	tmp, err := os.CreateTemp(filepath.Dir(f.path), filepath.Base(f.path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create token store temp file: %w", err)
 	}
-	if err := os.Rename(tmp, f.path); err != nil {
-		if f.logger != nil {
-			f.logger.Warn("failed to rename token store", "error", err, "path", f.path)
-		}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename below succeeds
+
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to set token store permissions: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to write token store: %w", err)
+	}
+	// Flush before the rename, or a power loss can leave a truncated file at
+	// the final path — the corruption the atomic write exists to prevent.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to flush token store: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close token store: %w", err)
+	}
+	if err := os.Rename(tmpName, f.path); err != nil {
+		return fmt.Errorf("failed to rename token store: %w", err)
+	}
+	return nil
+}
+
+// persistBestEffort records a persist failure without failing the originating
+// request.
+func (f *FileTokenStore) persistBestEffort() {
+	if err := f.persist(); err != nil && f.logger != nil {
+		f.logger.Warn("failed to persist token store", "error", err, "path", f.path)
 	}
 }
 
-// snapshot returns the current tokens under the read lock. Holding the lock for
-// the duration of the copy prevents a concurrent-map-iteration panic against
-// writers; marshalling happens after the lock is released in persist.
+// snapshot returns a copy of the current tokens under the read lock. The
+// entries must be cloned, not aliased: marshalling happens after the lock is
+// released, while ExtendTokenExpiry and UpdateGoogleToken mutate the stored
+// structs in place, so sharing the pointers would race and could serialise a
+// torn ExpiresAt as the authoritative expiry.
 func (f *FileTokenStore) snapshot() []*TokenInfo {
 	f.MemoryTokenStore.mu.RLock()
 	defer f.MemoryTokenStore.mu.RUnlock()
 
 	out := make([]*TokenInfo, 0, len(f.MemoryTokenStore.tokens))
 	for _, info := range f.MemoryTokenStore.tokens {
-		out = append(out, info)
+		out = append(out, cloneTokenInfo(info))
 	}
 	return out
 }

--- a/auth/file_token_store_test.go
+++ b/auth/file_token_store_test.go
@@ -1,0 +1,164 @@
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// newTestFileStore creates a FileTokenStore backed by a fresh temp file.
+func newTestFileStore(t *testing.T) (*FileTokenStore, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	store, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewFileTokenStore failed: %v", err)
+	}
+	return store, path
+}
+
+func sampleToken(access, refresh string) *TokenInfo {
+	return &TokenInfo{
+		AccessToken:      access,
+		RefreshToken:     refresh,
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		GoogleToken: &oauth2.Token{
+			AccessToken:  "google-access",
+			RefreshToken: "google-refresh",
+			Expiry:       time.Now().Add(1 * time.Hour),
+		},
+		ClientID:  "test-client",
+		CreatedAt: time.Now(),
+	}
+}
+
+// The core bug fix: a token stored before a "restart" must still be there
+// after the process (and its in-memory map) is recreated from the same file.
+func TestFileTokenStore_SurvivesRestart(t *testing.T) {
+	store, path := newTestFileStore(t)
+	if err := store.StoreToken(sampleToken("access-1", "refresh-1")); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+	store.Close()
+
+	// Simulate a restart: brand new store, same file.
+	reopened, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("reopen NewFileTokenStore failed: %v", err)
+	}
+	defer reopened.Close()
+
+	retrieved, err := reopened.GetTokenByAccess("access-1")
+	if err != nil {
+		t.Fatalf("token lost across restart: %v", err)
+	}
+	if retrieved.GoogleToken == nil || retrieved.GoogleToken.RefreshToken != "google-refresh" {
+		t.Errorf("Google refresh token not persisted, got %+v", retrieved.GoogleToken)
+	}
+}
+
+// After a restart, refresh-token lookups must work, which requires the
+// secondary refresh index to be rebuilt from the persisted file.
+func TestFileTokenStore_RefreshIndexRebuiltAfterRestart(t *testing.T) {
+	store, path := newTestFileStore(t)
+	if err := store.StoreToken(sampleToken("access-2", "refresh-2")); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+	store.Close()
+
+	reopened, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("reopen failed: %v", err)
+	}
+	defer reopened.Close()
+
+	if _, err := reopened.GetTokenByRefresh("refresh-2"); err != nil {
+		t.Fatalf("GetTokenByRefresh after restart failed: %v", err)
+	}
+}
+
+func TestFileTokenStore_DeletePersists(t *testing.T) {
+	store, path := newTestFileStore(t)
+	if err := store.StoreToken(sampleToken("access-3", "refresh-3")); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+	if err := store.DeleteToken("access-3"); err != nil {
+		t.Fatalf("DeleteToken failed: %v", err)
+	}
+	store.Close()
+
+	reopened, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("reopen failed: %v", err)
+	}
+	defer reopened.Close()
+
+	if _, err := reopened.GetTokenByAccess("access-3"); err != ErrTokenNotFound {
+		t.Errorf("expected ErrTokenNotFound after deletion+restart, got %v", err)
+	}
+}
+
+func TestFileTokenStore_UpdateGoogleTokenPersists(t *testing.T) {
+	store, path := newTestFileStore(t)
+	if err := store.StoreToken(sampleToken("access-4", "refresh-4")); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+	newGoogle := &oauth2.Token{AccessToken: "rotated", RefreshToken: "google-refresh", Expiry: time.Now().Add(time.Hour)}
+	if err := store.UpdateGoogleToken("access-4", newGoogle); err != nil {
+		t.Fatalf("UpdateGoogleToken failed: %v", err)
+	}
+	store.Close()
+
+	reopened, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("reopen failed: %v", err)
+	}
+	defer reopened.Close()
+
+	retrieved, err := reopened.GetTokenByAccess("access-4")
+	if err != nil {
+		t.Fatalf("GetTokenByAccess failed: %v", err)
+	}
+	if retrieved.GoogleToken.AccessToken != "rotated" {
+		t.Errorf("expected rotated google token, got %q", retrieved.GoogleToken.AccessToken)
+	}
+}
+
+// First run: no file on disk yet. The store must start empty, not error.
+func TestFileTokenStore_FirstRunNoFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "tokens.json")
+	store, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewFileTokenStore on missing file should succeed, got %v", err)
+	}
+	defer store.Close()
+
+	if _, err := store.GetTokenByAccess("anything"); err != ErrTokenNotFound {
+		t.Errorf("expected ErrTokenNotFound on empty store, got %v", err)
+	}
+}
+
+// Tokens whose refresh window has already lapsed are dead weight; they should
+// not be reloaded after a restart.
+func TestFileTokenStore_PrunesExpiredRefreshOnLoad(t *testing.T) {
+	store, path := newTestFileStore(t)
+	dead := sampleToken("access-dead", "refresh-dead")
+	dead.RefreshExpiresAt = time.Now().Add(-1 * time.Hour) // refresh window lapsed
+	if err := store.StoreToken(dead); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+	store.Close()
+
+	reopened, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("reopen failed: %v", err)
+	}
+	defer reopened.Close()
+
+	if _, err := reopened.GetTokenByAccessIncludeExpired("access-dead"); err != ErrTokenNotFound {
+		t.Errorf("expected expired-refresh token to be pruned on load, got %v", err)
+	}
+}

--- a/auth/file_token_store_test.go
+++ b/auth/file_token_store_test.go
@@ -1,7 +1,10 @@
 package auth
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -160,5 +163,87 @@ func TestFileTokenStore_PrunesExpiredRefreshOnLoad(t *testing.T) {
 
 	if _, err := reopened.GetTokenByAccessIncludeExpired("access-dead"); err != ErrTokenNotFound {
 		t.Errorf("expected expired-refresh token to be pruned on load, got %v", err)
+	}
+}
+
+// Persisting marshals a snapshot outside the store lock while other requests
+// mutate the same entries in place, so the snapshot has to be a copy. Run
+// under -race, this fails if the snapshot aliases the stored structs.
+func TestFileTokenStore_ConcurrentPersistAndMutation(t *testing.T) {
+	store, _ := newTestFileStore(t)
+	defer store.Close()
+
+	if err := store.StoreToken(sampleToken("access-1", "refresh-1")); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for n := 0; n < 25; n++ {
+				if err := store.ExtendTokenExpiry("access-1", time.Now().Add(time.Duration(n)*time.Minute)); err != nil {
+					t.Errorf("ExtendTokenExpiry failed: %v", err)
+					return
+				}
+				if err := store.StoreToken(sampleToken(fmt.Sprintf("access-%d-%d", i, n), "")); err != nil {
+					t.Errorf("StoreToken failed: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// os.WriteFile follows symlinks, so a fixed "<path>.tmp" would let anyone who
+// can create files in the directory siphon every refresh token elsewhere.
+func TestFileTokenStore_DoesNotWriteThroughPlantedTempSymlink(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tokens.json")
+	target := filepath.Join(dir, "attacker-readable")
+	if err := os.WriteFile(target, []byte("untouched"), 0o644); err != nil {
+		t.Fatalf("seeding target failed: %v", err)
+	}
+	if err := os.Symlink(target, path+".tmp"); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	store, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewFileTokenStore failed: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.StoreToken(sampleToken("access-1", "refresh-1")); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading target failed: %v", err)
+	}
+	if string(got) != "untouched" {
+		t.Errorf("tokens were written through the planted symlink: %s", got)
+	}
+}
+
+// A revocation that never reaches disk is valid again after a restart, so
+// unlike the other paths DeleteToken must not swallow a persist failure.
+func TestFileTokenStore_DeleteReportsPersistFailure(t *testing.T) {
+	store, path := newTestFileStore(t)
+	defer store.Close()
+
+	if err := store.StoreToken(sampleToken("access-1", "refresh-1")); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+	// Remove the directory out from under the store so the write cannot land.
+	if err := os.RemoveAll(filepath.Dir(path)); err != nil {
+		t.Fatalf("removing store dir failed: %v", err)
+	}
+
+	if err := store.DeleteToken("access-1"); err == nil {
+		t.Error("expected DeleteToken to report the persist failure")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	// Token configuration
 	AccessTokenTTL time.Duration
 
+	// TokenStorePath, when set, persists issued tokens to this JSON file so
+	// sessions survive restarts. Empty means in-memory only (the default).
+	TokenStorePath string
+
 	// AllowedHosts lists additional trusted hostnames for dynamic base URL resolution.
 	// Enables Docker-to-Docker contexts where the server is reached via internal aliases.
 	AllowedHosts []string
@@ -60,6 +64,7 @@ func Load() (*Config, error) {
 		JWTSecret:             getEnv("JWT_SECRET", ""),
 		LogLevel:              getEnv("LOG_LEVEL", "info"),
 		AccessTokenTTL:        getEnvDuration("ACCESS_TOKEN_TTL", 8*time.Hour),
+		TokenStorePath:        getEnv("TOKEN_STORE_PATH", ""),
 		AllowedHosts:          getEnvList("ALLOWED_HOSTS"),
 		ServiceAccountAPIKey:  getEnv("SERVICE_ACCOUNT_API_KEY", ""),
 		ServiceAccountKeyJSON: getEnv("GOOGLE_SERVICE_ACCOUNT_KEY_JSON", ""),

--- a/main.go
+++ b/main.go
@@ -134,8 +134,19 @@ func main() {
 	registerLimiter := middleware.NewRateLimiter(2, 5, cfg.TrustProxy) // 2 req/s, burst 5
 
 	if oauthConfigured {
-		// Set up OAuth
-		tokenStore = auth.NewMemoryTokenStore()
+		// Set up OAuth. Use a file-backed store when a path is configured so
+		// sessions survive restarts; otherwise fall back to in-memory.
+		if cfg.TokenStorePath != "" {
+			fileStore, err := auth.NewFileTokenStore(cfg.TokenStorePath, logger)
+			if err != nil {
+				logger.Error("failed to initialize file token store", "error", err, "path", cfg.TokenStorePath)
+				os.Exit(1)
+			}
+			tokenStore = fileStore
+			logger.Info("token persistence enabled", "path", cfg.TokenStorePath)
+		} else {
+			tokenStore = auth.NewMemoryTokenStore()
+		}
 		googleProvider := auth.NewGoogleProvider(
 			cfg.GoogleClientID,
 			cfg.GoogleClientSecret,


### PR DESCRIPTION
The second half of the persistence work offered on #74, split out as its own PR. Independent of #76 — this branch builds and tests clean without it, though the two are complementary.

Tokens live in memory only, so every restart logs all users out and forces a fresh OAuth flow. `TOKEN_STORE_PATH` points at a JSON file that the store loads at startup and rewrites after every token mutation. Unset keeps the in-memory default, so existing deployments are unchanged.

Only issued tokens are persisted. OAuth flow states (10-minute lifetime) and dynamically-registered clients are deliberately not: they are short-lived or re-created by the client on reconnect.

## On-disk handling

The file holds Google refresh tokens, so the write path is deliberate about it:

- created exclusively via `os.CreateTemp` with a random name, not a fixed `<path>.tmp`. `os.WriteFile` follows symlinks, so a predictable temp path lets anyone able to create files in the directory pre-plant a link and siphon every refresh token.
- `0600` file inside a `0700` directory, fsynced before the rename so a power loss cannot leave a truncated file at the final path.
- the snapshot passed to `json.Marshal` is a deep copy. Marshalling happens outside the store lock while `ExtendTokenExpiry` and `UpdateGoogleToken` mutate the entries in place under it — aliasing the pointers is a real race (`-race` confirms it), and a torn `time.Time` would serialise a garbage expiry that becomes authoritative on the next load.
- `DeleteToken` returns a persist failure rather than swallowing it: a revocation that never reaches disk is a valid token again after a restart. The add and update paths stay best-effort, since in-memory state is still correct for the running process.

A corrupt or unreadable file fails startup rather than silently discarding every session. That is deliberate, but worth knowing: it makes a damaged file an operator-visible event instead of a mass logout.

`gofmt -l`, `go vet`, `go build`, `go test -race ./...` clean.