### PR TITLE
feat(auth): add auto-refresh kill switch for the #79 canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,36 @@ TOKEN_STORE_PATH=/data/tokens.json
 
 The file is written with `0600` permissions and holds refresh tokens, so it belongs on a volume you would treat as secret. The directory must be writable by the user the server runs as (the Docker image runs as `appuser` and ships `/data` owned by it, mode `0700`; a directory the server creates itself gets the same mode) — the store fails closed, so a path that cannot be created or read stops the server at startup rather than silently discarding sessions. Leave `TOKEN_STORE_PATH` unset to keep the in-memory behaviour.
 
+#### Bearer Auto-Refresh (AUTH_AUTO_REFRESH)
+
+When a client presents an **expired** bearer, the server refreshes the upstream
+Google token and extends the *same* bearer in place, so the client never notices.
+That keeps sessions smooth, but it also means the bearer's expiry does not bound
+it: presenting an expired bearer is enough to be issued a fresh window, for as
+long as the refresh window is open (up to 30 days).
+
+Set `AUTH_AUTO_REFRESH=false` to turn that off. An expired bearer is then answered
+with `401` plus the RFC 9728 `WWW-Authenticate` header, and the client is expected
+to use the standard OAuth refresh grant — which rotates both credentials — to get
+a new one:
+
+```env
+AUTH_AUTO_REFRESH=false
+```
+
+Defaults to `true`, so leaving it unset changes nothing.
+
+This flag exists to run a canary (see issue #79) establishing which MCP clients
+actually implement the refresh grant. With it disabled, group the `auth_grant` log
+events by `client_name`:
+
+- `grant_type=refresh_token` — the client recovered silently. Good.
+- repeated `grant_type=authorization_code` — the client has no refresh grant and
+  falls back to interactive re-authentication every `ACCESS_TOKEN_TTL`.
+
+`auth_auto_refresh_disabled` counts the expired bearers that would have been
+renewed silently while the flag was on.
+
 ### Google Cloud Setup
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)

--- a/auth/file_token_store_test.go
+++ b/auth/file_token_store_test.go
@@ -247,3 +247,81 @@ func TestFileTokenStore_DeleteReportsPersistFailure(t *testing.T) {
 		t.Error("expected DeleteToken to report the persist failure")
 	}
 }
+
+// TestFileTokenStore_PersistsClientName pins client attribution across a
+// restart. TokenInfo is marshalled without json tags, so this guards the field
+// against being tagged out or renamed: a token whose ClientName does not
+// survive a reload is invisible to the #79 canary readout.
+func TestFileTokenStore_PersistsClientName(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+
+	store, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewFileTokenStore failed: %v", err)
+	}
+	if err := store.StoreToken(&TokenInfo{
+		AccessToken:      "access-1",
+		RefreshToken:     "refresh-1",
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		GoogleToken:      &oauth2.Token{AccessToken: "g-access", RefreshToken: "g-refresh"},
+		ClientID:         "client-abc",
+		ClientName:       "Claude Code",
+		CreatedAt:        time.Now(),
+	}); err != nil {
+		t.Fatalf("StoreToken failed: %v", err)
+	}
+	store.Close()
+
+	reloaded, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("reload failed: %v", err)
+	}
+	defer reloaded.Close()
+
+	got, err := reloaded.GetTokenByAccess("access-1")
+	if err != nil {
+		t.Fatalf("token missing after reload: %v", err)
+	}
+	if got.ClientName != "Claude Code" {
+		t.Errorf("ClientName after reload = %q, want %q", got.ClientName, "Claude Code")
+	}
+}
+
+// TestFileTokenStore_LoadsFileWithoutClientName covers the upgrade path: a store
+// file written before ClientName existed must still load, with an empty name
+// rather than a startup failure.
+func TestFileTokenStore_LoadsFileWithoutClientName(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+
+	legacy := fmt.Sprintf(`{"tokens":[{
+		"AccessToken":"access-1",
+		"RefreshToken":"refresh-1",
+		"ExpiresAt":%q,
+		"RefreshExpiresAt":%q,
+		"GoogleToken":{"access_token":"g-access","refresh_token":"g-refresh"},
+		"ClientID":"client-abc",
+		"CreatedAt":%q
+	}]}`,
+		time.Now().Add(1*time.Hour).Format(time.RFC3339Nano),
+		time.Now().Add(30*24*time.Hour).Format(time.RFC3339Nano),
+		time.Now().Format(time.RFC3339Nano))
+
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("writing legacy file failed: %v", err)
+	}
+
+	store, err := NewFileTokenStore(path, testLogger())
+	if err != nil {
+		t.Fatalf("a file predating ClientName must still load, got: %v", err)
+	}
+	defer store.Close()
+
+	got, err := store.GetTokenByAccess("access-1")
+	if err != nil {
+		t.Fatalf("token missing after loading legacy file: %v", err)
+	}
+	if got.ClientName != "" {
+		t.Errorf("ClientName = %q, want empty for a legacy entry", got.ClientName)
+	}
+}

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -423,6 +423,7 @@ func (s *Server) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Req
 		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
 		GoogleToken:      tempToken.GoogleToken,
 		ClientID:         codeState.ClientID,
+		ClientName:       s.clientName(codeState.ClientID),
 		CreatedAt:        time.Now(),
 	}
 
@@ -432,10 +433,25 @@ func (s *Server) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	s.logger.Info("issued access token", "client_id", codeState.ClientID)
+	s.logger.Info("auth_grant",
+		"grant_type", "authorization_code",
+		"client_id", tokenInfo.ClientID,
+		"client_name", tokenInfo.ClientName,
+	)
 
 	// Return token response
 	s.tokenResponse(w, accessToken, refreshToken, int(s.accessTokenTTL.Seconds()))
+}
+
+// clientName resolves the registered client_name for a client_id, best-effort:
+// clients that authenticated via CIMD were never registered, so an empty name is
+// a normal outcome rather than an error.
+func (s *Server) clientName(clientID string) string {
+	client, err := s.store.GetClient(clientID)
+	if err != nil || client == nil {
+		return ""
+	}
+	return client.ClientName
 }
 
 func (s *Server) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request) {
@@ -495,6 +511,7 @@ func (s *Server) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request)
 		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
 		GoogleToken:      tokenInfo.GoogleToken,
 		ClientID:         tokenInfo.ClientID,
+		ClientName:       tokenInfo.ClientName,
 		CreatedAt:        time.Now(),
 	}
 
@@ -504,7 +521,11 @@ func (s *Server) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	s.logger.Info("refreshed access token", "client_id", tokenInfo.ClientID)
+	s.logger.Info("auth_grant",
+		"grant_type", "refresh_token",
+		"client_id", tokenInfo.ClientID,
+		"client_name", tokenInfo.ClientName,
+	)
 
 	// Return token response with new refresh token
 	s.tokenResponse(w, newAccessToken, newRefreshToken, int(s.accessTokenTTL.Seconds()))

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 func TestIsValidRedirectURI(t *testing.T) {
@@ -914,5 +918,157 @@ func TestServer_CallbackHandler_IssUsesResolvedIssuerFromAuthorize(t *testing.T)
 
 	if got := loc.Query().Get("iss"); got != "http://gtm-mcp:8080" {
 		t.Errorf("expected iss=http://gtm-mcp:8080 (issuer resolved at authorize time), got %q", got)
+	}
+}
+
+// TestRefreshTokenGrant_CarriesClientNameThroughRotation keeps the canary
+// readout intact across a rotation. handleRefreshTokenGrant deletes the old
+// entry and stores a new one, so a ClientName that is not carried across would
+// blank out for exactly the long-lived sessions the #79 canary is about.
+func TestRefreshTokenGrant_CarriesClientNameThroughRotation(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	server := NewServer("http://localhost:8080", nil, store, logger, 1*time.Hour)
+
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "old-access",
+		RefreshToken:     "old-refresh",
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		GoogleToken:      &oauth2.Token{AccessToken: "g-access", Expiry: time.Now().Add(1 * time.Hour)},
+		ClientID:         "client-abc",
+		ClientName:       "Claude Code",
+		CreatedAt:        time.Now(),
+	})
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "old-refresh")
+
+	req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	server.TokenHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad token response: %v", err)
+	}
+
+	rotated, err := store.GetTokenByAccess(resp["access_token"].(string))
+	if err != nil {
+		t.Fatalf("rotated token not found: %v", err)
+	}
+	if rotated.ClientName != "Claude Code" {
+		t.Errorf("ClientName after rotation = %q, want %q", rotated.ClientName, "Claude Code")
+	}
+}
+
+// TestRefreshTokenGrant_LogsAuthGrantEvent is the canary's counting mechanism:
+// a client that recovers via the refresh grant must be distinguishable, by name,
+// from one that falls back to a full interactive re-auth.
+func TestRefreshTokenGrant_LogsAuthGrantEvent(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	server := NewServer("http://localhost:8080", nil, store, logger, 1*time.Hour)
+
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "old-access",
+		RefreshToken:     "old-refresh",
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		GoogleToken:      &oauth2.Token{AccessToken: "g-access", Expiry: time.Now().Add(1 * time.Hour)},
+		ClientID:         "client-abc",
+		ClientName:       "Claude Code",
+		CreatedAt:        time.Now(),
+	})
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "old-refresh")
+
+	req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	server.TokenHandler(httptest.NewRecorder(), req)
+
+	var found bool
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var entry map[string]interface{}
+		if json.Unmarshal([]byte(line), &entry) != nil {
+			continue
+		}
+		if entry["msg"] != "auth_grant" {
+			continue
+		}
+		found = true
+		if entry["grant_type"] != "refresh_token" {
+			t.Errorf("grant_type = %v, want refresh_token", entry["grant_type"])
+		}
+		if entry["client_name"] != "Claude Code" {
+			t.Errorf("client_name = %v, want %q", entry["client_name"], "Claude Code")
+		}
+		if entry["client_id"] != "client-abc" {
+			t.Errorf("client_id = %v, want client-abc", entry["client_id"])
+		}
+	}
+	if !found {
+		t.Errorf("no auth_grant event logged; got: %s", buf.String())
+	}
+}
+
+// TestAuthGrantLog_DoesNotLeakTokens guards the new log line against the class
+// of bug fixed in #74.
+func TestAuthGrantLog_DoesNotLeakTokens(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	server := NewServer("http://localhost:8080", nil, store, logger, 1*time.Hour)
+
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "supersecretaccess",
+		RefreshToken:     "supersecretrefresh",
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		GoogleToken:      &oauth2.Token{AccessToken: "g-access", Expiry: time.Now().Add(1 * time.Hour)},
+		ClientID:         "client-abc",
+		ClientName:       "Claude Code",
+		CreatedAt:        time.Now(),
+	})
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "supersecretrefresh")
+
+	req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	server.TokenHandler(w, req)
+
+	logs := buf.String()
+	for _, secret := range []string{"supersecretaccess", "supersecretrefresh"} {
+		if strings.Contains(logs, secret) {
+			t.Errorf("logs leaked %q: %s", secret, logs)
+		}
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	for _, k := range []string{"access_token", "refresh_token"} {
+		if tok, ok := resp[k].(string); ok && strings.Contains(logs, tok) {
+			t.Errorf("logs leaked the newly issued %s", k)
+		}
 	}
 }

--- a/auth/integration_test.go
+++ b/auth/integration_test.go
@@ -18,7 +18,7 @@ func TestIntegration_MetadataAndMiddleware401_Consistency(t *testing.T) {
 
 	// Both use nil resolver — static URLs
 	metaHandler := MetadataHandler(baseURL, nil)
-	mw := Middleware(store, nil, logger, baseURL, 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, baseURL, 1*time.Hour, nil, nil, "", true)
 	protectedHandler := mw(dummyHandler)
 
 	// Fetch metadata
@@ -62,7 +62,7 @@ func TestIntegration_MetadataAndMiddleware401_ConsistencyWithResolver(t *testing
 
 	metaHandler := MetadataHandler(baseURL, resolver)
 	resHandler := ProtectedResourceMetadataHandler(baseURL, baseURL, resolver)
-	mw := Middleware(store, nil, logger, baseURL, 1*time.Hour, resolver, nil, "")
+	mw := Middleware(store, nil, logger, baseURL, 1*time.Hour, resolver, nil, "", true)
 	protectedHandler := mw(dummyHandler)
 
 	// Test with the allowed Docker host
@@ -141,7 +141,7 @@ func TestIntegration_UntrustedHostDoesNotLeakIntoResponses(t *testing.T) {
 	handlers := map[string]http.Handler{
 		"metadata":           MetadataHandler(baseURL, resolver),
 		"protected_resource": ProtectedResourceMetadataHandler(baseURL, baseURL, resolver),
-		"middleware_401":     Middleware(store, nil, logger, baseURL, 1*time.Hour, resolver, nil, "")(dummyHandler),
+		"middleware_401":     Middleware(store, nil, logger, baseURL, 1*time.Hour, resolver, nil, "", true)(dummyHandler),
 	}
 
 	for name, handler := range handlers {

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -33,7 +33,7 @@ const (
 // If a token is expired but has a valid refresh token, it will automatically
 // refresh the token and continue the request transparently.
 // If resolver is non-nil, 401 responses will use dynamically resolved URLs.
-func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, baseURL string, accessTokenTTL time.Duration, resolver *URLResolver, saTokenSource oauth2.TokenSource, apiKey string) func(http.Handler) http.Handler {
+func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, baseURL string, accessTokenTTL time.Duration, resolver *URLResolver, saTokenSource oauth2.TokenSource, apiKey string, autoRefreshEnabled bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Resolve the base URL for error responses
@@ -77,6 +77,20 @@ func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, b
 			tokenInfo, err := store.GetTokenByAccess(accessToken)
 			if err != nil {
 				if err == ErrTokenExpired {
+					// Auto-refresh renews the bearer in place without rotating it,
+					// so its expiry bounds nothing (issue #79). The kill switch
+					// answers 401 instead: unauthorized() carries the RFC 9728
+					// WWW-Authenticate header, so a client that implements the
+					// refresh grant recovers on its own.
+					if !autoRefreshEnabled {
+						logger.Info("auth_auto_refresh_disabled",
+							"token_fp", tokenFingerprint(accessToken),
+							"action", "reject",
+						)
+						unauthorized(w, effectiveURL, "Token expired")
+						return
+					}
+
 					// Attempt auto-refresh
 					tokenInfo, err = tryAutoRefresh(r.Context(), store, google, logger, accessToken, baseURL, accessTokenTTL)
 					if err != nil {

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -133,7 +133,7 @@ func TestMiddleware_ValidToken(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -154,7 +154,7 @@ func TestMiddleware_MissingAuthHeader(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -183,7 +183,7 @@ func TestMiddleware_InvalidFormat(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -201,7 +201,7 @@ func TestMiddleware_TokenNotFound(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -249,7 +249,7 @@ func TestMiddleware_ExpiredToken_AutoRefreshSuccess(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -297,7 +297,7 @@ func TestMiddleware_ExpiredToken_NoRefreshToken(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -334,7 +334,7 @@ func TestMiddleware_ExpiredToken_ExpiredRefreshToken(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -379,7 +379,7 @@ func TestMiddleware_ExpiredToken_GoogleRefreshFails(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -487,7 +487,7 @@ func TestMiddleware_AuthFailedLogDoesNotLeakToken(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	mw := Middleware(newMockTokenStore(), nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "")
+	mw := Middleware(newMockTokenStore(), nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	const token = "sekrit-bearer-token-value"
@@ -528,7 +528,7 @@ func TestMiddleware_ExpiredTokenLogDoesNotLeakToken(t *testing.T) {
 		ExpiresAt:   time.Now().Add(-time.Hour),
 	})
 
-	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -556,7 +556,7 @@ func TestMiddleware_ErrorResponseFormat(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()
 
-	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "", true)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -630,7 +630,7 @@ func TestMiddleware_ContextValues(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", true)
 	handler := mw(captureHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -667,7 +667,7 @@ func TestMiddleware_ContextValues(t *testing.T) {
 
 // saMiddlewareWithOAuth is a helper that builds Middleware with S2S configured.
 func saMiddlewareWithOAuth(store TokenStore, apiKey string, saTS oauth2.TokenSource) func(http.Handler) http.Handler {
-	return Middleware(store, nil, testLogger(), "http://localhost:8080", 1*time.Hour, nil, saTS, apiKey)
+	return Middleware(store, nil, testLogger(), "http://localhost:8080", 1*time.Hour, nil, saTS, apiKey, true)
 }
 
 func TestMiddleware_SAMode_CorrectKey(t *testing.T) {
@@ -805,5 +805,123 @@ func TestMiddleware_OAuthUser_NoSATokenSource(t *testing.T) {
 		t.Error("OAuth user must have their own Google token in context")
 	} else if got.AccessToken != "google-oauth-token" {
 		t.Errorf("expected user's Google token, got %q", got.AccessToken)
+	}
+}
+
+// TestMiddleware_AutoRefreshDisabled_ExpiredTokenGets401 is the kill switch for
+// the #79 canary: with auto-refresh off, an expired bearer is answered with a
+// 401 carrying the RFC 9728 WWW-Authenticate header, so a grant-capable client
+// recovers via the refresh grant rather than having its bearer silently renewed.
+func TestMiddleware_AutoRefreshDisabled_ExpiredTokenGets401(t *testing.T) {
+	store := newMockTokenStore()
+	logger := testLogger()
+
+	googleTokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Google token endpoint must not be called when auto-refresh is disabled")
+	}))
+	defer googleTokenServer.Close()
+
+	google := newTestGoogleProvider(googleTokenServer.URL)
+
+	originalExpiry := time.Now().Add(-1 * time.Hour)
+	token := &TokenInfo{
+		AccessToken:      "expired-token",
+		RefreshToken:     "our-refresh-token",
+		ExpiresAt:        originalExpiry,
+		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		GoogleToken: &oauth2.Token{
+			AccessToken:  "old-google-access",
+			RefreshToken: "google-refresh-token",
+			Expiry:       time.Now().Add(-1 * time.Hour),
+		},
+		ClientID:  "test-client",
+		CreatedAt: time.Now(),
+	}
+	store.StoreToken(token)
+
+	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", false)
+	handler := mw(dummyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer expired-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401 with auto-refresh disabled, got %d", w.Code)
+	}
+	if got := w.Header().Get("WWW-Authenticate"); got == "" {
+		t.Error("expected WWW-Authenticate header so the client can discover the token endpoint")
+	}
+
+	// The bearer must not be renewed: expiry unchanged, Google token untouched.
+	stored, err := store.GetTokenByAccessIncludeExpired("expired-token")
+	if err != nil {
+		t.Fatalf("expected token entry to survive: %v", err)
+	}
+	if !stored.ExpiresAt.Equal(originalExpiry) {
+		t.Errorf("expiry was extended to %v, want it left at %v", stored.ExpiresAt, originalExpiry)
+	}
+	if stored.GoogleToken.AccessToken != "old-google-access" {
+		t.Errorf("Google token was refreshed (%q) with auto-refresh disabled", stored.GoogleToken.AccessToken)
+	}
+}
+
+// TestMiddleware_AutoRefreshDisabled_ValidTokenStillWorks guards the blast
+// radius of the kill switch: it must only affect the expired-bearer branch.
+func TestMiddleware_AutoRefreshDisabled_ValidTokenStillWorks(t *testing.T) {
+	store := newMockTokenStore()
+	store.StoreToken(&TokenInfo{
+		AccessToken: "valid-token",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+		GoogleToken: &oauth2.Token{AccessToken: "google-access"},
+		ClientID:    "test-client",
+		CreatedAt:   time.Now(),
+	})
+
+	mw := Middleware(store, nil, testLogger(), "http://localhost:8080", 1*time.Hour, nil, nil, "", false)
+	handler := mw(dummyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200 for a live token, got %d", w.Code)
+	}
+}
+
+// TestMiddleware_AutoRefreshDisabled_LogsCanaryEvent gives the canary window a
+// countable event for bearers that would have been renewed silently before.
+func TestMiddleware_AutoRefreshDisabled_LogsCanaryEvent(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	store := newMockTokenStore()
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "expired-token",
+		RefreshToken:     "our-refresh-token",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		GoogleToken:      &oauth2.Token{AccessToken: "old-google-access", RefreshToken: "g-refresh"},
+		ClientID:         "test-client",
+		CreatedAt:        time.Now(),
+	})
+
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", false)
+	handler := mw(dummyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer expired-token")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !strings.Contains(buf.String(), "auth_auto_refresh_disabled") {
+		t.Errorf("expected an auth_auto_refresh_disabled event, got logs: %s", buf.String())
+	}
+	if strings.Contains(buf.String(), "expired-token") {
+		t.Error("canary log leaked the bearer token")
 	}
 }

--- a/auth/token_store.go
+++ b/auth/token_store.go
@@ -30,8 +30,14 @@ type TokenInfo struct {
 	GoogleToken *oauth2.Token
 
 	// Metadata
-	ClientID  string
-	CreatedAt time.Time
+	ClientID string
+	// ClientName is the registered client_name, copied onto the token at issue
+	// time. Registered clients are not persisted (see FileTokenStore), so
+	// resolving the name lazily would lose it across a restart for exactly the
+	// long-lived sessions the #79 canary needs to attribute. Empty for clients
+	// that never registered (CIMD).
+	ClientName string
+	CreatedAt  time.Time
 }
 
 // AuthState holds temporary state during OAuth flow.

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,13 @@ type Config struct {
 	// TrustProxy enables trusting X-Forwarded-For for rate limiting.
 	// Set to true when behind a reverse proxy (e.g. Caddy).
 	TrustProxy bool
+
+	// AutoRefreshEnabled controls whether an expired bearer is transparently
+	// renewed by the auth middleware. Disabling it makes the server answer 401
+	// instead, so clients must use the OAuth refresh grant. See issue #79: this
+	// is the kill switch for the canary that establishes which clients
+	// implement the grant.
+	AutoRefreshEnabled bool
 }
 
 // Load reads configuration from environment variables.
@@ -69,6 +76,7 @@ func Load() (*Config, error) {
 		ServiceAccountAPIKey:  getEnv("SERVICE_ACCOUNT_API_KEY", ""),
 		ServiceAccountKeyJSON: getEnv("GOOGLE_SERVICE_ACCOUNT_KEY_JSON", ""),
 		TrustProxy:            getEnvBool("TRUST_PROXY", false),
+		AutoRefreshEnabled:    getEnvBool("AUTH_AUTO_REFRESH", true),
 	}
 
 	// Validation is deferred to when auth is actually needed

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestAutoRefreshEnabled_DefaultsTrue pins the deploy-safe default: existing
+// deployments that never set AUTH_AUTO_REFRESH keep today's auto-refresh
+// behaviour. The flag exists to be switched off for a canary window (#79).
+func TestAutoRefreshEnabled_DefaultsTrue(t *testing.T) {
+	os.Unsetenv("AUTH_AUTO_REFRESH")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if !cfg.AutoRefreshEnabled {
+		t.Error("AutoRefreshEnabled = false with AUTH_AUTO_REFRESH unset, want true")
+	}
+}
+
+func TestAutoRefreshEnabled_HonoursEnv(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"false", false},
+		{"0", false},
+		{"true", true},
+		{"1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv("AUTH_AUTO_REFRESH", tt.value)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load failed: %v", err)
+			}
+
+			if cfg.AutoRefreshEnabled != tt.want {
+				t.Errorf("AUTH_AUTO_REFRESH=%q gave AutoRefreshEnabled=%v, want %v", tt.value, cfg.AutoRefreshEnabled, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func main() {
 
 		// MCP endpoint with REQUIRED auth middleware and body size limit
 		// Returns 401 if no valid Bearer token - triggers Claude's OAuth flow
-		authMiddleware := auth.Middleware(tokenStore, googleProvider, logger, cfg.BaseURL, cfg.AccessTokenTTL, urlResolver, saTokenSource, cfg.ServiceAccountAPIKey)
+		authMiddleware := auth.Middleware(tokenStore, googleProvider, logger, cfg.BaseURL, cfg.AccessTokenTTL, urlResolver, saTokenSource, cfg.ServiceAccountAPIKey, cfg.AutoRefreshEnabled)
 		mux.Handle("/", authMiddleware(maxBytesHandler(5<<20, mcpHandler)))
 
 		logger.Info("OAuth configured",
@@ -194,7 +194,7 @@ func main() {
 		mux.HandleFunc("POST /token", oauthLimiter.MiddlewareFunc(oauthNotConfiguredHandler))
 		mux.HandleFunc("POST /register", registerLimiter.MiddlewareFunc(oauthNotConfiguredHandler))
 
-		s2sMiddleware := auth.Middleware(auth.NewMemoryTokenStore(), nil, logger, cfg.BaseURL, cfg.AccessTokenTTL, urlResolver, saTokenSource, cfg.ServiceAccountAPIKey)
+		s2sMiddleware := auth.Middleware(auth.NewMemoryTokenStore(), nil, logger, cfg.BaseURL, cfg.AccessTokenTTL, urlResolver, saTokenSource, cfg.ServiceAccountAPIKey, cfg.AutoRefreshEnabled)
 		mux.Handle("/", s2sMiddleware(maxBytesHandler(5<<20, mcpHandler)))
 	} else {
 		logger.Warn("No authentication configured (no OAuth, no API key), running open")


### PR DESCRIPTION
Closes the instrumentation half of #79 — the canary this enables is what decides the issue.

## Why not just log on the existing branch

`auth_auto_refresh_success` cannot answer "which clients implement the refresh grant". While auto-refresh exists, no client ever *needs* the grant, so that counter measures clients presenting expired bearers, not clients lacking the grant. Logging on it for a release would produce a number that looks like evidence and isn't. This is NoSync's point on #79 and it's right.

## What this adds

**`AUTH_AUTO_REFRESH`** (default `true`, so existing deployments are unchanged). Set `false` and an expired bearer gets a 401 instead of a silent in-place renewal. `unauthorized()` already emits the RFC 9728 `WWW-Authenticate` header, so recovery is spec-driven rather than client-specific — nothing client-shaped had to be added.

**`auth_grant`** replaces the two unstructured lines at the token endpoint, matching the `auth_*` event naming already used in middleware:

```
auth_grant grant_type=refresh_token       client_id=... client_name=...
auth_grant grant_type=authorization_code  client_id=... client_name=...
```

Group by `client_name` during the canary window: `refresh_token` = recovered silently; repeated `authorization_code` = no refresh grant, regressing to interactive re-auth every `ACCESS_TOKEN_TTL`, i.e. exactly the UX #76 fixed. `auth_auto_refresh_disabled` counts the bearers that would have been renewed silently.

**`ClientName` on `TokenInfo`**, stamped at issue time instead of resolved lazily. Registered clients are deliberately not persisted by the file store (#77), so a lazy `GetClient` lookup would blank the name across a restart — for precisely the long-lived sessions the canary is about. Carried across the rotation in `handleRefreshTokenGrant`, which stores a new entry and deletes the old. `TokenInfo` has no json tags, so it round-trips the file store as-is and a file written before the field existed loads with an empty name. CIMD clients never registered, so an empty name is a normal outcome there, not an error.

## Scope

Removing `tryAutoRefresh` is deliberately **not** here — that's the decision the canary informs, and it belongs in its own PR once the numbers exist. If some client does regress, option 3 on #79 (an absolute cap on the renewal chain) is the fallback and this flag is not the mechanism for it.

The 9th positional parameter on `auth.Middleware` is knowingly ugly. It's temporary: if the canary comes back clean the whole branch and this flag go away together, and an options-struct refactor would leave more behind than it removes.

## Testing

TDD throughout; every test was watched failing first. The file-store persistence test was verified to genuinely fail by temporarily tagging the field `json:"-"` — it caught it.

- kill switch: expired bearer + disabled → 401 with `WWW-Authenticate`, expiry **not** extended, Google token untouched, and the Google token endpoint asserted never called
- blast radius: a live token still passes with the flag off
- `auth_auto_refresh_disabled` is emitted and does not leak the bearer
- `ClientName` survives a refresh-grant rotation
- `auth_grant` carries `grant_type`/`client_id`/`client_name`, and leaks neither the presented nor the newly issued tokens (guarding the #74 class of bug)
- file store round-trips `ClientName`; a legacy file without the key loads rather than failing startup
- config: defaults true when unset, honours `true`/`false`/`1`/`0`

`gofmt -l`, `go vet`, `go build`, `go test -race ./...`, `staticcheck ./...` all clean.

## Canary procedure

Deploy with `AUTH_AUTO_REFRESH=false`, leave it for at least one `ACCESS_TOKEN_TTL` (8h) so sessions actually expire, then group `auth_grant` by `client_name` and check each client in the README — Claude Code, ChatGPT, Cursor, VS Code — appears with `refresh_token` and not repeated `authorization_code`.