### PR TITLE
fix(auth): cap the silent bearer renewal chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,34 @@ TOKEN_STORE_PATH=/data/tokens.json
 
 The file is written with `0600` permissions and holds refresh tokens, so it belongs on a volume you would treat as secret. The directory must be writable by the user the server runs as (the Docker image runs as `appuser` and ships `/data` owned by it, mode `0700`; a directory the server creates itself gets the same mode) — the store fails closed, so a path that cannot be created or read stops the server at startup rather than silently discarding sessions. Leave `TOKEN_STORE_PATH` unset to keep the in-memory behaviour.
 
+#### Bearer Renewal Cap (AUTH_AUTO_REFRESH_MAX_AGE)
+
+When a client presents an **expired** bearer, the server refreshes the upstream
+Google token and extends the *same* bearer in place, so the session continues
+without an interactive login. Because the bearer is never rotated, its expiry
+does not bound it on its own: presenting an expired bearer is enough to be issued
+a fresh window, for as long as the entry survives.
+
+`AUTH_AUTO_REFRESH_MAX_AGE` bounds that chain by absolute age since the token was
+issued. Default `168h` (7 days):
+
+```env
+AUTH_AUTO_REFRESH_MAX_AGE=168h
+```
+
+Past the cap, an expired bearer gets `401` plus the RFC 9728 `WWW-Authenticate`
+header instead of a silent renewal. The client then uses the standard OAuth
+refresh grant, which **rotates both credentials** and issues a new entry with a
+fresh age — so a well-behaved client crosses the cap without the user noticing,
+and it is the leaked-bearer chain that dies.
+
+A client with no refresh grant re-authenticates interactively once per cap period
+rather than once per `ACCESS_TOKEN_TTL`. Set the value to `0` to disable the cap
+entirely and restore unbounded renewal.
+
+`auth_auto_refresh_capped` logs each rejection, with `client_id` and the age of
+the chain that was refused.
+
 ### Google Cloud Setup
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 func TestIsValidRedirectURI(t *testing.T) {
@@ -914,5 +918,55 @@ func TestServer_CallbackHandler_IssUsesResolvedIssuerFromAuthorize(t *testing.T)
 
 	if got := loc.Query().Get("iss"); got != "http://gtm-mcp:8080" {
 		t.Errorf("expected iss=http://gtm-mcp:8080 (issuer resolved at authorize time), got %q", got)
+	}
+}
+
+// TestRefreshTokenGrant_ResetsChainAge is load-bearing for the #79 cap. The cap
+// measures age from CreatedAt, and the refresh grant is the sanctioned way past
+// it: because it rotates both credentials, the new entry earns a fresh window.
+// If rotation carried the old CreatedAt forward, a capped client could never
+// recover and would be forced into interactive re-auth instead.
+func TestRefreshTokenGrant_ResetsChainAge(t *testing.T) {
+	store := NewMemoryTokenStore()
+	defer store.Close()
+
+	server := NewServer("http://localhost:8080", nil, store,
+		slog.New(slog.NewTextHandler(io.Discard, nil)), 1*time.Hour)
+
+	oldCreatedAt := time.Now().Add(-10 * 24 * time.Hour)
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "old-access",
+		RefreshToken:     "old-refresh",
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(20 * 24 * time.Hour),
+		GoogleToken:      &oauth2.Token{AccessToken: "g-access", Expiry: time.Now().Add(1 * time.Hour)},
+		ClientID:         "client-abc",
+		CreatedAt:        oldCreatedAt,
+	})
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "old-refresh")
+
+	req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	server.TokenHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad token response: %v", err)
+	}
+
+	rotated, err := store.GetTokenByAccess(resp["access_token"].(string))
+	if err != nil {
+		t.Fatalf("rotated token not found: %v", err)
+	}
+	if !rotated.CreatedAt.After(oldCreatedAt.Add(24 * time.Hour)) {
+		t.Errorf("rotation carried the old chain age forward (CreatedAt=%v); a capped client could never recover", rotated.CreatedAt)
 	}
 }

--- a/auth/integration_test.go
+++ b/auth/integration_test.go
@@ -18,7 +18,7 @@ func TestIntegration_MetadataAndMiddleware401_Consistency(t *testing.T) {
 
 	// Both use nil resolver — static URLs
 	metaHandler := MetadataHandler(baseURL, nil)
-	mw := Middleware(store, nil, logger, baseURL, 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, baseURL, 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	protectedHandler := mw(dummyHandler)
 
 	// Fetch metadata
@@ -62,7 +62,7 @@ func TestIntegration_MetadataAndMiddleware401_ConsistencyWithResolver(t *testing
 
 	metaHandler := MetadataHandler(baseURL, resolver)
 	resHandler := ProtectedResourceMetadataHandler(baseURL, baseURL, resolver)
-	mw := Middleware(store, nil, logger, baseURL, 1*time.Hour, resolver, nil, "")
+	mw := Middleware(store, nil, logger, baseURL, 1*time.Hour, resolver, nil, "", 7*24*time.Hour)
 	protectedHandler := mw(dummyHandler)
 
 	// Test with the allowed Docker host
@@ -141,7 +141,7 @@ func TestIntegration_UntrustedHostDoesNotLeakIntoResponses(t *testing.T) {
 	handlers := map[string]http.Handler{
 		"metadata":           MetadataHandler(baseURL, resolver),
 		"protected_resource": ProtectedResourceMetadataHandler(baseURL, baseURL, resolver),
-		"middleware_401":     Middleware(store, nil, logger, baseURL, 1*time.Hour, resolver, nil, "")(dummyHandler),
+		"middleware_401":     Middleware(store, nil, logger, baseURL, 1*time.Hour, resolver, nil, "", 7*24*time.Hour)(dummyHandler),
 	}
 
 	for name, handler := range handlers {

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -33,7 +33,7 @@ const (
 // If a token is expired but has a valid refresh token, it will automatically
 // refresh the token and continue the request transparently.
 // If resolver is non-nil, 401 responses will use dynamically resolved URLs.
-func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, baseURL string, accessTokenTTL time.Duration, resolver *URLResolver, saTokenSource oauth2.TokenSource, apiKey string) func(http.Handler) http.Handler {
+func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, baseURL string, accessTokenTTL time.Duration, resolver *URLResolver, saTokenSource oauth2.TokenSource, apiKey string, autoRefreshMaxAge time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Resolve the base URL for error responses
@@ -78,7 +78,7 @@ func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, b
 			if err != nil {
 				if err == ErrTokenExpired {
 					// Attempt auto-refresh
-					tokenInfo, err = tryAutoRefresh(r.Context(), store, google, logger, accessToken, baseURL, accessTokenTTL)
+					tokenInfo, err = tryAutoRefresh(r.Context(), store, google, logger, accessToken, baseURL, accessTokenTTL, autoRefreshMaxAge)
 					if err != nil {
 						unauthorized(w, effectiveURL, err.Error())
 						return
@@ -111,7 +111,7 @@ func Middleware(store TokenStore, google *GoogleProvider, logger *slog.Logger, b
 // tryAutoRefresh attempts to refresh an expired token transparently.
 // It refreshes the Google token and updates the EXISTING token entry in-place,
 // keeping the same access token so the client's bearer token remains valid.
-func tryAutoRefresh(ctx context.Context, store TokenStore, google *GoogleProvider, logger *slog.Logger, accessToken string, baseURL string, accessTokenTTL time.Duration) (*TokenInfo, error) {
+func tryAutoRefresh(ctx context.Context, store TokenStore, google *GoogleProvider, logger *slog.Logger, accessToken string, baseURL string, accessTokenTTL time.Duration, maxAge time.Duration) (*TokenInfo, error) {
 	logger.Info("auth_token_expired", "token_fp", tokenFingerprint(accessToken), "action", "auto_refresh")
 
 	// Get the expired token info (including refresh token)
@@ -125,6 +125,21 @@ func tryAutoRefresh(ctx context.Context, store TokenStore, google *GoogleProvide
 	if expiredToken.RefreshToken == "" || expiredToken.GoogleToken == nil || expiredToken.GoogleToken.RefreshToken == "" {
 		logger.Warn("auth_auto_refresh_failed", "reason", "no_refresh_token", "client_id", expiredToken.ClientID)
 		return nil, fmt.Errorf("Token expired, no refresh token available")
+	}
+
+	// Bound the silent renewal chain (issue #79). Auto-refresh extends the same
+	// bearer rather than rotating it, so its expiry bounds nothing on its own and
+	// a leaked bearer would stay useful for the whole refresh window. Past maxAge
+	// the client must use the refresh grant, which rotates both credentials and
+	// starts a new entry with a fresh CreatedAt. A non-positive maxAge disables
+	// the cap.
+	if maxAge > 0 && time.Since(expiredToken.CreatedAt) > maxAge {
+		logger.Info("auth_auto_refresh_capped",
+			"client_id", expiredToken.ClientID,
+			"chain_age", time.Since(expiredToken.CreatedAt).Round(time.Minute).String(),
+			"max_age", maxAge.String(),
+		)
+		return nil, fmt.Errorf("Token expired")
 	}
 
 	// Check refresh token hasn't expired

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -133,7 +133,7 @@ func TestMiddleware_ValidToken(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -154,7 +154,7 @@ func TestMiddleware_MissingAuthHeader(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -183,7 +183,7 @@ func TestMiddleware_InvalidFormat(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -201,7 +201,7 @@ func TestMiddleware_TokenNotFound(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -249,7 +249,7 @@ func TestMiddleware_ExpiredToken_AutoRefreshSuccess(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -297,7 +297,7 @@ func TestMiddleware_ExpiredToken_NoRefreshToken(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -334,7 +334,7 @@ func TestMiddleware_ExpiredToken_ExpiredRefreshToken(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -379,7 +379,7 @@ func TestMiddleware_ExpiredToken_GoogleRefreshFails(t *testing.T) {
 	}
 	store.StoreToken(token)
 
-	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -487,7 +487,7 @@ func TestMiddleware_AuthFailedLogDoesNotLeakToken(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	mw := Middleware(newMockTokenStore(), nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "")
+	mw := Middleware(newMockTokenStore(), nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	const token = "sekrit-bearer-token-value"
@@ -528,7 +528,7 @@ func TestMiddleware_ExpiredTokenLogDoesNotLeakToken(t *testing.T) {
 		ExpiresAt:   time.Now().Add(-time.Hour),
 	})
 
-	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -556,7 +556,7 @@ func TestMiddleware_ErrorResponseFormat(t *testing.T) {
 	store := newMockTokenStore()
 	logger := testLogger()
 
-	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, nil, logger, "https://mcp.gtmeditor.com", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(dummyHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -630,7 +630,7 @@ func TestMiddleware_ContextValues(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "")
+	mw := Middleware(store, google, logger, "http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
 	handler := mw(captureHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -667,7 +667,7 @@ func TestMiddleware_ContextValues(t *testing.T) {
 
 // saMiddlewareWithOAuth is a helper that builds Middleware with S2S configured.
 func saMiddlewareWithOAuth(store TokenStore, apiKey string, saTS oauth2.TokenSource) func(http.Handler) http.Handler {
-	return Middleware(store, nil, testLogger(), "http://localhost:8080", 1*time.Hour, nil, saTS, apiKey)
+	return Middleware(store, nil, testLogger(), "http://localhost:8080", 1*time.Hour, nil, saTS, apiKey, 7*24*time.Hour)
 }
 
 func TestMiddleware_SAMode_CorrectKey(t *testing.T) {
@@ -805,5 +805,143 @@ func TestMiddleware_OAuthUser_NoSATokenSource(t *testing.T) {
 		t.Error("OAuth user must have their own Google token in context")
 	} else if got.AccessToken != "google-oauth-token" {
 		t.Errorf("expected user's Google token, got %q", got.AccessToken)
+	}
+}
+
+// TestMiddleware_AutoRefreshCapped_RejectsOldChain is the bound from issue #79.
+// Auto-refresh renews a bearer in place without rotating it, so without an
+// absolute cap a bearer captured from a log or a proxy stays useful for the
+// whole 30-day refresh window. Past the cap the server stops renewing.
+func TestMiddleware_AutoRefreshCapped_RejectsOldChain(t *testing.T) {
+	store := newMockTokenStore()
+
+	googleTokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Google token endpoint must not be called past the renewal cap")
+	}))
+	defer googleTokenServer.Close()
+
+	originalExpiry := time.Now().Add(-1 * time.Hour)
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "old-chain-token",
+		RefreshToken:     "our-refresh-token",
+		ExpiresAt:        originalExpiry,
+		RefreshExpiresAt: time.Now().Add(20 * 24 * time.Hour), // refresh window still open
+		GoogleToken: &oauth2.Token{
+			AccessToken:  "old-google-access",
+			RefreshToken: "google-refresh-token",
+			Expiry:       time.Now().Add(-1 * time.Hour),
+		},
+		ClientID:  "test-client",
+		CreatedAt: time.Now().Add(-8 * 24 * time.Hour), // issued 8 days ago
+	})
+
+	mw := Middleware(store, newTestGoogleProvider(googleTokenServer.URL), testLogger(),
+		"http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
+	handler := mw(dummyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer old-chain-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 past the renewal cap, got %d", w.Code)
+	}
+	if w.Header().Get("WWW-Authenticate") == "" {
+		t.Error("expected WWW-Authenticate so the client can reach the refresh grant")
+	}
+
+	stored, err := store.GetTokenByAccessIncludeExpired("old-chain-token")
+	if err != nil {
+		t.Fatalf("entry should survive so the refresh grant still works: %v", err)
+	}
+	if !stored.ExpiresAt.Equal(originalExpiry) {
+		t.Errorf("bearer was renewed past the cap: expiry moved to %v", stored.ExpiresAt)
+	}
+}
+
+// TestMiddleware_AutoRefreshCapped_AllowsYoungChain keeps the everyday case
+// working: this is the silent overnight renewal that #76 exists to enable.
+func TestMiddleware_AutoRefreshCapped_AllowsYoungChain(t *testing.T) {
+	store := newMockTokenStore()
+
+	googleTokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "new-google-access", "token_type": "Bearer", "expires_in": 3600,
+		})
+	}))
+	defer googleTokenServer.Close()
+
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "young-chain-token",
+		RefreshToken:     "our-refresh-token",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		GoogleToken: &oauth2.Token{
+			AccessToken:  "old-google-access",
+			RefreshToken: "google-refresh-token",
+			Expiry:       time.Now().Add(-1 * time.Hour),
+		},
+		ClientID:  "test-client",
+		CreatedAt: time.Now().Add(-16 * time.Hour), // overnight gap, well inside the cap
+	})
+
+	mw := Middleware(store, newTestGoogleProvider(googleTokenServer.URL), testLogger(),
+		"http://localhost:8080", 1*time.Hour, nil, nil, "", 7*24*time.Hour)
+	handler := mw(dummyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer young-chain-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for a chain inside the cap, got %d", w.Code)
+	}
+}
+
+// TestMiddleware_AutoRefreshCap_ZeroDisables keeps an escape hatch: a zero or
+// negative cap means "no cap", so an operator can restore the old behaviour
+// without a code change.
+func TestMiddleware_AutoRefreshCap_ZeroDisables(t *testing.T) {
+	store := newMockTokenStore()
+
+	googleTokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "new-google-access", "token_type": "Bearer", "expires_in": 3600,
+		})
+	}))
+	defer googleTokenServer.Close()
+
+	store.StoreToken(&TokenInfo{
+		AccessToken:      "ancient-token",
+		RefreshToken:     "our-refresh-token",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(20 * 24 * time.Hour),
+		GoogleToken: &oauth2.Token{
+			AccessToken:  "old-google-access",
+			RefreshToken: "google-refresh-token",
+			Expiry:       time.Now().Add(-1 * time.Hour),
+		},
+		ClientID:  "test-client",
+		CreatedAt: time.Now().Add(-100 * 24 * time.Hour),
+	})
+
+	mw := Middleware(store, newTestGoogleProvider(googleTokenServer.URL), testLogger(),
+		"http://localhost:8080", 1*time.Hour, nil, nil, "", 0)
+	handler := mw(dummyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer ancient-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with the cap disabled, got %d", w.Code)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,13 @@ type Config struct {
 	// TrustProxy enables trusting X-Forwarded-For for rate limiting.
 	// Set to true when behind a reverse proxy (e.g. Caddy).
 	TrustProxy bool
+
+	// AutoRefreshMaxAge bounds the silent renewal chain. tryAutoRefresh extends a
+	// bearer in place without rotating it, so its expiry bounds nothing on its
+	// own; past this age since the token was issued the server stops renewing and
+	// answers 401, forcing the client through the refresh grant, which does
+	// rotate. See issue #79.
+	AutoRefreshMaxAge time.Duration
 }
 
 // Load reads configuration from environment variables.
@@ -69,6 +76,7 @@ func Load() (*Config, error) {
 		ServiceAccountAPIKey:  getEnv("SERVICE_ACCOUNT_API_KEY", ""),
 		ServiceAccountKeyJSON: getEnv("GOOGLE_SERVICE_ACCOUNT_KEY_JSON", ""),
 		TrustProxy:            getEnvBool("TRUST_PROXY", false),
+		AutoRefreshMaxAge:     getEnvDuration("AUTH_AUTO_REFRESH_MAX_AGE", 7*24*time.Hour),
 	}
 
 	// Validation is deferred to when auth is actually needed

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestAutoRefreshMaxAge_DefaultsToSevenDays pins the bound on the renewal chain.
+// Auto-refresh renews a bearer without rotating it, so without an absolute cap a
+// leaked bearer stays useful for the whole refresh window (issue #79).
+func TestAutoRefreshMaxAge_DefaultsToSevenDays(t *testing.T) {
+	os.Unsetenv("AUTH_AUTO_REFRESH_MAX_AGE")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if want := 7 * 24 * time.Hour; cfg.AutoRefreshMaxAge != want {
+		t.Errorf("AutoRefreshMaxAge = %v, want %v", cfg.AutoRefreshMaxAge, want)
+	}
+}
+
+func TestAutoRefreshMaxAge_HonoursEnv(t *testing.T) {
+	t.Setenv("AUTH_AUTO_REFRESH_MAX_AGE", "48h")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if want := 48 * time.Hour; cfg.AutoRefreshMaxAge != want {
+		t.Errorf("AutoRefreshMaxAge = %v, want %v", cfg.AutoRefreshMaxAge, want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func main() {
 
 		// MCP endpoint with REQUIRED auth middleware and body size limit
 		// Returns 401 if no valid Bearer token - triggers Claude's OAuth flow
-		authMiddleware := auth.Middleware(tokenStore, googleProvider, logger, cfg.BaseURL, cfg.AccessTokenTTL, urlResolver, saTokenSource, cfg.ServiceAccountAPIKey)
+		authMiddleware := auth.Middleware(tokenStore, googleProvider, logger, cfg.BaseURL, cfg.AccessTokenTTL, urlResolver, saTokenSource, cfg.ServiceAccountAPIKey, cfg.AutoRefreshMaxAge)
 		mux.Handle("/", authMiddleware(maxBytesHandler(5<<20, mcpHandler)))
 
 		logger.Info("OAuth configured",
@@ -194,7 +194,7 @@ func main() {
 		mux.HandleFunc("POST /token", oauthLimiter.MiddlewareFunc(oauthNotConfiguredHandler))
 		mux.HandleFunc("POST /register", registerLimiter.MiddlewareFunc(oauthNotConfiguredHandler))
 
-		s2sMiddleware := auth.Middleware(auth.NewMemoryTokenStore(), nil, logger, cfg.BaseURL, cfg.AccessTokenTTL, urlResolver, saTokenSource, cfg.ServiceAccountAPIKey)
+		s2sMiddleware := auth.Middleware(auth.NewMemoryTokenStore(), nil, logger, cfg.BaseURL, cfg.AccessTokenTTL, urlResolver, saTokenSource, cfg.ServiceAccountAPIKey, cfg.AutoRefreshMaxAge)
 		mux.Handle("/", s2sMiddleware(maxBytesHandler(5<<20, mcpHandler)))
 	} else {
 		logger.Warn("No authentication configured (no OAuth, no API key), running open")


### PR DESCRIPTION
Closes #79 — taking **option 3** (cap the renewal chain) rather than option 2 (drop auto-refresh behind a canary).

## Why option 3, after starting on option 2

Option 2 was the more correct answer in the abstract, and the staged canary on #79 was the right way to de-risk it. Two facts killed it in practice:

1. **A user reported having to log in every morning.** Diagnosed today: prod runs an 8h `ACCESS_TOKEN_TTL`, the old cleanup purged entries an hour after access expiry, and the container has been up 2 weeks with `restartCount=0` — so this is the #76 bug exactly, not restarts. The canary works by turning auto-refresh *off* for a window, which re-creates that symptom for any client lacking the refresh grant. Doing that days after fixing it is a bad trade.
2. **There is no log monitoring on the deployment.** The canary's whole output is `auth_grant` events grouped by `client_name`, read by a human over an 8h+ soak. An experiment nobody is positioned to observe is not an experiment.

The cap needs no observation, breaks no client, and bounds the leak regardless of which clients turn out to implement the grant.

## What it does

`AUTH_AUTO_REFRESH_MAX_AGE`, default **168h (7 days)**, measured from `CreatedAt`. Past it, an expired bearer gets a 401 with the RFC 9728 `WWW-Authenticate` header instead of a silent in-place renewal.

The recovery path is the point: the refresh grant **rotates both credentials** and stores a new entry with a fresh `CreatedAt`, so a grant-capable client crosses the cap without an interactive login and the chain resets. What dies is the non-rotating chain — a bearer captured from a log or a proxy is useful for at most 7 days instead of 30. A client with no refresh grant re-authenticates once a week rather than once a day, still a large improvement on the pre-#76 behaviour. `0` disables the cap.

Enforced *before* the upstream Google refresh, so a refused chain costs no network call, and the entry is left untouched so the refresh grant can still resolve it.

## Testing

TDD; every test watched failing first.

- an 8-day-old chain is refused: 401, `WWW-Authenticate` present, expiry **not** moved, and the Google token endpoint asserted never called
- a 16-hour-old chain (the overnight case #76 exists for) still renews silently
- a zero cap disables the bound
- **`TestRefreshTokenGrant_ResetsChainAge`** — load-bearing, since the cap is only humane if rotation resets the age. Verified it genuinely bites by temporarily carrying `CreatedAt` forward: it fails with "a capped client could never recover."
- config: defaults to 168h, honours `AUTH_AUTO_REFRESH_MAX_AGE=48h`

`gofmt -l`, `go vet`, `go build`, `go test -race ./...`, `staticcheck ./...` clean.

## Relationship to #84

#84 (the kill switch + `auth_grant` logging) is the option-2 groundwork and is **not** needed for this. Its `auth_grant`/`client_name` logging is still independently useful if you ever want client attribution, but the canary it was built for is off the table. Both touch the `auth.Middleware` signature, so whichever lands second needs a trivial conflict fix — happy to close #84 instead if you'd rather not carry it.