### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var llmsTxt string
 
 const (
 	serverName    = "gtm-mcp-server"
-	serverVersion = "1.8.2"
+	serverVersion = "1.9.0"
 )
 
 func main() {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paolobietolini/gtm-mcp-server",
   "title": "GTM MCP Server",
   "description": "Let AI manage your Google Tag Manager containers — tags, triggers, variables, and more.",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Bumps `serverVersion` (main.go) and `version` (server.json) together, ahead of deploying #76 + #77.

Minor rather than patch: #77 adds `TOKEN_STORE_PATH`, a new operator-facing feature; #76 is the cleanup fix behind the daily re-login reports.

Needed before the deploy so `/health` distinguishes the new build from the 1.8.2 currently running — otherwise there is no way to confirm from outside that the deploy landed.