### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var llmsTxt string
 
 const (
 	serverName    = "gtm-mcp-server"
-	serverVersion = "1.9.0"
+	serverVersion = "1.10.0"
 )
 
 func main() {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paolobietolini/gtm-mcp-server",
   "title": "GTM MCP Server",
   "description": "Let AI manage your Google Tag Manager containers — tags, triggers, variables, and more.",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Bumps `serverVersion` (main.go) and `version` (server.json) together, ahead of deploying #85.

Minor rather than patch: #85 adds `AUTH_AUTO_REFRESH_MAX_AGE` as a new operator-facing knob and changes what happens to a bearer past the cap.

Needed before the deploy so `/health` distinguishes the new build from the 1.9.0 currently running.