### PR TITLE
perf(tools): trim repeated text from tool descriptions

### DIFF
--- a/gtm/tool_built_in_variables.go
+++ b/gtm/tool_built_in_variables.go
@@ -10,9 +10,9 @@ import (
 // -- List Built-In Variables --
 
 type ListBuiltInVariablesInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 
 type ListBuiltInVariablesOutput struct {
@@ -43,9 +43,9 @@ func registerListBuiltInVariables(server *mcp.Server) {
 // -- Enable Built-In Variables --
 
 type EnableBuiltInVariablesInput struct {
-	AccountID   string   `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string   `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string   `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string   `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string   `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string   `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Types       []string `json:"types" jsonschema:"description:Array of built-in variable types to enable (e.g. eventName, clientName, requestPath, pageUrl, event)"`
 }
 
@@ -87,11 +87,11 @@ func registerEnableBuiltInVariables(server *mcp.Server) {
 // -- Disable Built-In Variables --
 
 type DisableBuiltInVariablesInput struct {
-	AccountID   string   `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string   `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string   `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string   `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string   `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string   `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Types       []string `json:"types" jsonschema:"description:Array of built-in variable types to disable"`
-	Confirm     bool     `json:"confirm" jsonschema:"description:Must be true to confirm disabling. This is a safety guard."`
+	Confirm     bool     `json:"confirm" jsonschema:"description:Must be true to confirm disabling."`
 }
 
 type DisableBuiltInVariablesOutput struct {

--- a/gtm/tool_clients.go
+++ b/gtm/tool_clients.go
@@ -9,9 +9,9 @@ import (
 // -- List Clients --
 
 type ListClientsInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 
 type ListClientsOutput struct {
@@ -42,9 +42,9 @@ func registerListClients(server *mcp.Server) {
 // -- Get Client --
 
 type GetClientInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	ClientID    string `json:"clientId" jsonschema:"description:The client ID to retrieve"`
 }
 

--- a/gtm/tool_containers.go
+++ b/gtm/tool_containers.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ListContainersInput struct {
-	AccountID string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	AccountID string `json:"accountId" jsonschema:"description:GTM account ID"`
 }
 type ListContainersOutput struct {
 	Containers []Container `json:"containers"`

--- a/gtm/tool_create_client.go
+++ b/gtm/tool_create_client.go
@@ -9,9 +9,9 @@ import (
 
 // CreateClientInput is the input for create_client tool.
 type CreateClientInput struct {
-	AccountID      string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID    string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID    string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID      string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID    string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID    string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Name           string `json:"name" jsonschema:"description:Client name"`
 	Type           string `json:"type" jsonschema:"description:Client type (e.g. __ga4 for GA4, __googtag for Google tag)"`
 	Priority       int64  `json:"priority,omitempty" jsonschema:"description:Client priority (optional, higher runs first)"`

--- a/gtm/tool_create_container.go
+++ b/gtm/tool_create_container.go
@@ -10,7 +10,7 @@ import (
 
 // CreateContainerInput is the input for create_container tool.
 type CreateContainerInput struct {
-	AccountID         string   `json:"accountId" jsonschema:"description:The GTM account ID"`
+	AccountID         string   `json:"accountId" jsonschema:"description:GTM account ID"`
 	Name              string   `json:"name" jsonschema:"description:Container display name"`
 	UsageContext      []string `json:"usageContext" jsonschema:"description:Usage context for the container. Valid values: web, android, ios, amp, server"`
 	Notes             string   `json:"notes,omitempty" jsonschema:"description:Container notes (optional)"`

--- a/gtm/tool_create_tag.go
+++ b/gtm/tool_create_tag.go
@@ -11,9 +11,9 @@ import (
 
 // CreateTagInput is the input for create_tag tool.
 type CreateTagInput struct {
-	AccountID          string   `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID        string   `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID        string   `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID          string   `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID        string   `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID        string   `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Name               string   `json:"name" jsonschema:"description:Tag name"`
 	Type               string   `json:"type" jsonschema:"description:Tag type (e.g. gaawe for GA4, html for Custom HTML)"`
 	FiringTriggerIDs   []string `json:"firingTriggerIds" jsonschema:"description:Array of trigger IDs that fire this tag"`

--- a/gtm/tool_create_template.go
+++ b/gtm/tool_create_template.go
@@ -10,9 +10,9 @@ import (
 
 // CreateTemplateInput is the input for create_template tool.
 type CreateTemplateInput struct {
-	AccountID    string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID  string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID  string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID    string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID  string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID  string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Name         string `json:"name" jsonschema:"description:Template display name"`
 	TemplateData string `json:"templateData" jsonschema:"description:The template code in .tpl format (the full template file content)"`
 }

--- a/gtm/tool_create_transformation.go
+++ b/gtm/tool_create_transformation.go
@@ -9,9 +9,9 @@ import (
 
 // CreateTransformationInput is the input for create_transformation tool.
 type CreateTransformationInput struct {
-	AccountID      string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID    string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID    string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID      string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID    string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID    string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Name           string `json:"name" jsonschema:"description:Transformation name"`
 	Type           string `json:"type" jsonschema:"description:Transformation type. Valid values: tf_exclude_params (exclude parameters from tags), tf_allow_params (allow only specified parameters), tf_augment_event (add/modify event parameters)"`
 	ParametersJSON string `json:"parametersJson,omitempty" jsonschema:"description:Transformation parameters as JSON array (optional). Each parameter: {type, key, value} or {type, key, list/map}"`

--- a/gtm/tool_create_trigger.go
+++ b/gtm/tool_create_trigger.go
@@ -9,9 +9,9 @@ import (
 
 // CreateTriggerInput is the input for create_trigger tool.
 type CreateTriggerInput struct {
-	AccountID             string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID           string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID           string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID             string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID           string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID           string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Name                  string `json:"name" jsonschema:"description:Trigger name"`
 	Type                  string `json:"type" jsonschema:"description:Trigger type (e.g. pageview, customEvent, linkClick, formSubmission, timer)"`
 	FilterJSON            string `json:"filterJson,omitempty" jsonschema:"description:Filter conditions as JSON array for pageview triggers. Condition types: equals\\, contains\\, doesNotContain\\, startsWith\\, endsWith\\, matchRegex. Each condition has type and parameter array with arg0 (variable) and arg1 (value). (optional)"`

--- a/gtm/tool_create_variable.go
+++ b/gtm/tool_create_variable.go
@@ -9,9 +9,9 @@ import (
 
 // CreateVariableInput is the input for create_variable tool.
 type CreateVariableInput struct {
-	AccountID      string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID    string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID    string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID      string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID    string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID    string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Name           string `json:"name" jsonschema:"description:Variable name"`
 	Type           string `json:"type" jsonschema:"description:Variable type (e.g. c for Constant, v for Data Layer, k for Cookie, jsm for Custom JavaScript)"`
 	ParametersJSON string `json:"parametersJson,omitempty" jsonschema:"description:Variable parameters as JSON array (required for most types)"`

--- a/gtm/tool_create_workspace.go
+++ b/gtm/tool_create_workspace.go
@@ -10,8 +10,8 @@ import (
 
 // CreateWorkspaceInput is the input for create_workspace tool.
 type CreateWorkspaceInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
 	Name        string `json:"name" jsonschema:"description:Workspace display name"`
 	Description string `json:"description,omitempty" jsonschema:"description:Workspace description (optional)"`
 }

--- a/gtm/tool_delete_client.go
+++ b/gtm/tool_delete_client.go
@@ -9,11 +9,11 @@ import (
 
 // DeleteClientInput is the input for delete_client tool.
 type DeleteClientInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	ClientID    string `json:"clientId" jsonschema:"description:The client ID to delete"`
-	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion. This is a safety guard."`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion."`
 }
 
 // DeleteClientOutput is the output for delete_client tool.

--- a/gtm/tool_delete_container.go
+++ b/gtm/tool_delete_container.go
@@ -9,9 +9,9 @@ import (
 
 // DeleteContainerInput is the input for delete_container tool.
 type DeleteContainerInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion. This is a safety guard."`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion."`
 }
 
 // DeleteContainerOutput is the output for delete_container tool.

--- a/gtm/tool_delete_tag.go
+++ b/gtm/tool_delete_tag.go
@@ -9,11 +9,11 @@ import (
 
 // DeleteTagInput is the input for delete_tag tool.
 type DeleteTagInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TagID       string `json:"tagId" jsonschema:"description:The tag ID to delete"`
-	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion. This is a safety guard."`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion."`
 }
 
 // DeleteTagOutput is the output for delete_tag tool.

--- a/gtm/tool_delete_template.go
+++ b/gtm/tool_delete_template.go
@@ -9,11 +9,11 @@ import (
 
 // DeleteTemplateInput is the input for delete_template tool.
 type DeleteTemplateInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TemplateID  string `json:"templateId" jsonschema:"description:The template ID to delete"`
-	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion. This is a safety guard."`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion."`
 }
 
 // DeleteTemplateOutput is the output for delete_template tool.

--- a/gtm/tool_delete_transformation.go
+++ b/gtm/tool_delete_transformation.go
@@ -9,11 +9,11 @@ import (
 
 // DeleteTransformationInput is the input for delete_transformation tool.
 type DeleteTransformationInput struct {
-	AccountID        string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID      string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID      string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID        string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID      string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID      string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TransformationID string `json:"transformationId" jsonschema:"description:The transformation ID to delete"`
-	Confirm          bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion. This is a safety guard."`
+	Confirm          bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion."`
 }
 
 // DeleteTransformationOutput is the output for delete_transformation tool.

--- a/gtm/tool_delete_trigger.go
+++ b/gtm/tool_delete_trigger.go
@@ -9,11 +9,11 @@ import (
 
 // DeleteTriggerInput is the input for delete_trigger tool.
 type DeleteTriggerInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TriggerID   string `json:"triggerId" jsonschema:"description:The trigger ID to delete"`
-	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion. This is a safety guard."`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion."`
 }
 
 // DeleteTriggerOutput is the output for delete_trigger tool.

--- a/gtm/tool_delete_variable.go
+++ b/gtm/tool_delete_variable.go
@@ -9,11 +9,11 @@ import (
 
 // DeleteVariableInput is the input for delete_variable tool.
 type DeleteVariableInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	VariableID  string `json:"variableId" jsonschema:"description:The variable ID to delete"`
-	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion. This is a safety guard."`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm deletion."`
 }
 
 // DeleteVariableOutput is the output for delete_variable tool.

--- a/gtm/tool_folders.go
+++ b/gtm/tool_folders.go
@@ -8,9 +8,9 @@ import (
 
 // ListFoldersInput is the input for list_folders tool.
 type ListFoldersInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 
 // ListFoldersOutput is the output for list_folders tool.
@@ -20,9 +20,9 @@ type ListFoldersOutput struct {
 
 // GetFolderEntitiesInput is the input for get_folder_entities tool.
 type GetFolderEntitiesInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	FolderID    string `json:"folderId" jsonschema:"description:The folder ID"`
 }
 

--- a/gtm/tool_get_template.go
+++ b/gtm/tool_get_template.go
@@ -10,9 +10,9 @@ import (
 
 // GetTemplateInput is the input for get_template tool.
 type GetTemplateInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TemplateID  string `json:"templateId" jsonschema:"description:The template ID to retrieve"`
 }
 

--- a/gtm/tool_get_trigger.go
+++ b/gtm/tool_get_trigger.go
@@ -8,9 +8,9 @@ import (
 )
 
 type GetTriggerInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TriggerID   string `json:"triggerId" jsonschema:"description:The trigger ID to retrieve"`
 }
 type GetTriggerOutput struct {

--- a/gtm/tool_get_variable.go
+++ b/gtm/tool_get_variable.go
@@ -8,9 +8,9 @@ import (
 )
 
 type GetVariableInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	VariableID  string `json:"variableId" jsonschema:"description:The variable ID to retrieve"`
 }
 type GetVariableOutput struct {

--- a/gtm/tool_import_gallery_template.go
+++ b/gtm/tool_import_gallery_template.go
@@ -9,9 +9,9 @@ import (
 
 // ImportGalleryTemplateInput is the input for import_gallery_template tool.
 type ImportGalleryTemplateInput struct {
-	AccountID    string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID  string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID  string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID    string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID  string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID  string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	GalleryOwner string `json:"galleryOwner" jsonschema:"description:Owner of the Gallery template (e.g. 'iubenda' or 'GoogleAnalytics')"`
 	GalleryRepo  string `json:"galleryRepository" jsonschema:"description:Repository of the Gallery template (e.g. 'gtm-cookie-solution')"`
 	GallerySha   string `json:"gallerySha,omitempty" jsonschema:"description:SHA version of the Gallery template. Defaults to latest if not provided"`

--- a/gtm/tool_list_templates.go
+++ b/gtm/tool_list_templates.go
@@ -10,9 +10,9 @@ import (
 
 // ListTemplatesInput is the input for list_templates tool.
 type ListTemplatesInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 
 // ListTemplatesOutput is the output for list_templates tool.

--- a/gtm/tool_list_versions.go
+++ b/gtm/tool_list_versions.go
@@ -10,8 +10,8 @@ import (
 
 // ListVersionsInput is the input for list_versions tool.
 type ListVersionsInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
 }
 
 // ListVersionsOutput is the output for list_versions tool.

--- a/gtm/tool_tags.go
+++ b/gtm/tool_tags.go
@@ -7,18 +7,18 @@ import (
 )
 
 type ListTagsInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 type ListTagsOutput struct {
 	Tags []Tag `json:"tags"`
 }
 
 type GetTagInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TagID       string `json:"tagId" jsonschema:"description:The tag ID to retrieve"`
 }
 type GetTagOutput struct {

--- a/gtm/tool_transformations.go
+++ b/gtm/tool_transformations.go
@@ -9,9 +9,9 @@ import (
 // -- List Transformations --
 
 type ListTransformationsInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 
 type ListTransformationsOutput struct {
@@ -42,9 +42,9 @@ func registerListTransformations(server *mcp.Server) {
 // -- Get Transformation --
 
 type GetTransformationInput struct {
-	AccountID        string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID      string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID      string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID        string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID      string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID      string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TransformationID string `json:"transformationId" jsonschema:"description:The transformation ID to retrieve"`
 }
 

--- a/gtm/tool_triggers.go
+++ b/gtm/tool_triggers.go
@@ -7,9 +7,9 @@ import (
 )
 
 type ListTriggersInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 type ListTriggersOutput struct {
 	Triggers []Trigger `json:"triggers"`

--- a/gtm/tool_update_account.go
+++ b/gtm/tool_update_account.go
@@ -9,7 +9,7 @@ import (
 
 // UpdateAccountInput is the input for update_account tool.
 type UpdateAccountInput struct {
-	AccountID string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	AccountID string `json:"accountId" jsonschema:"description:GTM account ID"`
 	Name      string `json:"name" jsonschema:"description:New account display name"`
 }
 

--- a/gtm/tool_update_client.go
+++ b/gtm/tool_update_client.go
@@ -10,9 +10,9 @@ import (
 
 // UpdateClientInput is the input for update_client tool.
 type UpdateClientInput struct {
-	AccountID      string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID    string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID    string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID      string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID    string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID    string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	ClientID       string `json:"clientId" jsonschema:"description:The client ID to update"`
 	Name           string `json:"name" jsonschema:"description:Client name"`
 	Type           string `json:"type" jsonschema:"description:Client type"`

--- a/gtm/tool_update_container.go
+++ b/gtm/tool_update_container.go
@@ -9,8 +9,8 @@ import (
 
 // UpdateContainerInput is the input for update_container tool.
 type UpdateContainerInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
 	Name        string `json:"name" jsonschema:"description:New container display name"`
 }
 

--- a/gtm/tool_update_tag.go
+++ b/gtm/tool_update_tag.go
@@ -11,21 +11,21 @@ import (
 
 // UpdateTagInput is the input for update_tag tool.
 type UpdateTagInput struct {
-	AccountID          string   `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID        string   `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID        string   `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID          string   `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID        string   `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID        string   `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TagID              string   `json:"tagId" jsonschema:"description:The tag ID to update"`
-	Name               string   `json:"name,omitempty" jsonschema:"description:Tag name. If omitted\\, existing name is preserved."`
-	Type               string   `json:"type,omitempty" jsonschema:"description:Tag type. If omitted\\, existing type is preserved."`
-	FiringTriggerIDs   []string `json:"firingTriggerIds,omitempty" jsonschema:"description:Array of trigger IDs that fire this tag. If omitted\\, existing triggers are preserved."`
-	BlockingTriggerIDs []string `json:"blockingTriggerIds,omitempty" jsonschema:"description:Array of trigger IDs that block this tag. If omitted\\, existing blocking triggers are preserved."`
-	ParametersJSON     string   `json:"parametersJson,omitempty" jsonschema:"description:Tag parameters as JSON array. If omitted\\, existing parameters (pixel IDs\\, measurement IDs\\, etc.) are preserved."`
-	SetupTagJSON       string   `json:"setupTagJson,omitempty" jsonschema:"description:Setup tag sequencing as JSON array. Each element: {tagName: string\\, stopOnSetupFailure: bool}. Pass [] to clear. If omitted\\, existing setup tags are preserved."`
-	TeardownTagJSON    string   `json:"teardownTagJson,omitempty" jsonschema:"description:Teardown tag sequencing as JSON array. Each element: {tagName: string\\, stopTeardownOnFailure: bool}. Pass [] to clear. If omitted\\, existing teardown tags are preserved."`
-	ConsentStatus      string   `json:"consentStatus,omitempty" jsonschema:"description:Consent status: notSet (default/clear)\\, notNeeded (no consent required)\\, needed (requires consent types to be granted before firing). If omitted\\, existing consent settings are preserved."`
+	Name               string   `json:"name,omitempty" jsonschema:"description:Tag name"`
+	Type               string   `json:"type,omitempty" jsonschema:"description:Tag type"`
+	FiringTriggerIDs   []string `json:"firingTriggerIds,omitempty" jsonschema:"description:Array of trigger IDs that fire this tag"`
+	BlockingTriggerIDs []string `json:"blockingTriggerIds,omitempty" jsonschema:"description:Array of trigger IDs that block this tag"`
+	ParametersJSON     string   `json:"parametersJson,omitempty" jsonschema:"description:Tag parameters as JSON array (pixel IDs\\, measurement IDs)"`
+	SetupTagJSON       string   `json:"setupTagJson,omitempty" jsonschema:"description:Setup tag sequencing as JSON array. Each element: {tagName: string\\, stopOnSetupFailure: bool}. Pass [] to clear"`
+	TeardownTagJSON    string   `json:"teardownTagJson,omitempty" jsonschema:"description:Teardown tag sequencing as JSON array. Each element: {tagName: string\\, stopTeardownOnFailure: bool}. Pass [] to clear"`
+	ConsentStatus      string   `json:"consentStatus,omitempty" jsonschema:"description:Consent status: notSet (default/clear)\\, notNeeded (no consent required)\\, needed (requires consent types to be granted before firing)"`
 	ConsentTypes       string   `json:"consentTypes,omitempty" jsonschema:"description:Comma-separated consent types when consentStatus is needed (e.g. ad_storage\\,analytics_storage\\,ad_user_data\\,ad_personalization). Ignored when consentStatus is notSet or notNeeded."`
-	Notes              string   `json:"notes,omitempty" jsonschema:"description:Tag notes. If omitted\\, existing notes are preserved."`
-	Paused             *bool    `json:"paused,omitempty" jsonschema:"description:Whether tag is paused. If omitted\\, existing paused state is preserved."`
+	Notes              string   `json:"notes,omitempty" jsonschema:"description:Tag notes"`
+	Paused             *bool    `json:"paused,omitempty" jsonschema:"description:Whether tag is paused"`
 }
 
 // UpdateTagOutput is the output for update_tag tool.

--- a/gtm/tool_update_template.go
+++ b/gtm/tool_update_template.go
@@ -10,9 +10,9 @@ import (
 
 // UpdateTemplateInput is the input for update_template tool.
 type UpdateTemplateInput struct {
-	AccountID    string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID  string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID  string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID    string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID  string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID  string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TemplateID   string `json:"templateId" jsonschema:"description:The template ID to update"`
 	Name         string `json:"name,omitempty" jsonschema:"description:Internal template name (optional). Note: This is NOT the visible display name. The visible name comes from the displayName field inside the ___INFO___ section of templateData."`
 	TemplateData string `json:"templateData,omitempty" jsonschema:"description:New template code in .tpl format (optional)"`

--- a/gtm/tool_update_transformation.go
+++ b/gtm/tool_update_transformation.go
@@ -10,9 +10,9 @@ import (
 
 // UpdateTransformationInput is the input for update_transformation tool.
 type UpdateTransformationInput struct {
-	AccountID        string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID      string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID      string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID        string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID      string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID      string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TransformationID string `json:"transformationId" jsonschema:"description:The transformation ID to update"`
 	Name             string `json:"name" jsonschema:"description:Transformation name"`
 	Type             string `json:"type,omitempty" jsonschema:"description:Transformation type (optional). Valid values: tf_exclude_params, tf_allow_params, tf_augment_event"`

--- a/gtm/tool_update_trigger.go
+++ b/gtm/tool_update_trigger.go
@@ -10,9 +10,9 @@ import (
 
 // UpdateTriggerInput is the input for update_trigger tool.
 type UpdateTriggerInput struct {
-	AccountID             string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID           string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID           string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID             string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID           string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID           string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	TriggerID             string `json:"triggerId" jsonschema:"description:The trigger ID to update"`
 	Name                  string `json:"name" jsonschema:"description:Trigger name"`
 	Type                  string `json:"type" jsonschema:"description:Trigger type (e.g. pageview, customEvent, linkClick, triggerGroup)"`

--- a/gtm/tool_update_variable.go
+++ b/gtm/tool_update_variable.go
@@ -10,9 +10,9 @@ import (
 
 // UpdateVariableInput is the input for update_variable tool.
 type UpdateVariableInput struct {
-	AccountID      string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID    string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID    string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID      string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID    string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID    string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	VariableID     string `json:"variableId" jsonschema:"description:The variable ID to update"`
 	Name           string `json:"name" jsonschema:"description:Variable name"`
 	Type           string `json:"type" jsonschema:"description:Variable type (e.g. c for Constant, v for Data Layer, k for Cookie, jsm for Custom JavaScript)"`

--- a/gtm/tool_variables.go
+++ b/gtm/tool_variables.go
@@ -7,9 +7,9 @@ import (
 )
 
 type ListVariablesInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 type ListVariablesOutput struct {
 	Variables []Variable `json:"variables"`

--- a/gtm/tool_version.go
+++ b/gtm/tool_version.go
@@ -9,9 +9,9 @@ import (
 
 // CreateVersionInput is the input for create_version tool.
 type CreateVersionInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 	Name        string `json:"name,omitempty" jsonschema:"description:Version name (optional)"`
 	Notes       string `json:"notes,omitempty" jsonschema:"description:Version notes describing changes (optional)"`
 }
@@ -25,10 +25,10 @@ type CreateVersionOutput struct {
 
 // PublishVersionInput is the input for publish_version tool.
 type PublishVersionInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
 	VersionID   string `json:"versionId" jsonschema:"description:The version ID to publish"`
-	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm publishing. This is a safety guard - publishing makes changes live."`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm publishing. Publishing makes changes live."`
 }
 
 // PublishVersionOutput is the output for publish_version tool.

--- a/gtm/tool_workspace_status.go
+++ b/gtm/tool_workspace_status.go
@@ -7,9 +7,9 @@ import (
 )
 
 type GetWorkspaceStatusInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
-	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:GTM workspace ID"`
 }
 type GetWorkspaceStatusOutput struct {
 	Status WorkspaceStatus `json:"status"`

--- a/gtm/tool_workspaces.go
+++ b/gtm/tool_workspaces.go
@@ -7,8 +7,8 @@ import (
 )
 
 type ListWorkspacesInput struct {
-	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
-	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	AccountID   string `json:"accountId" jsonschema:"description:GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:GTM container ID"`
 }
 type ListWorkspacesOutput struct {
 	Workspaces []Workspace `json:"workspaces"`


### PR DESCRIPTION
## The measurement first

The `tools/list` payload is sent on **every conversation**, before the user asks anything.

| | Bytes | ≈ Tokens |
|---|---|---|
| Before | 62,379 | 15,594 |
| After | 61,142 | 15,285 |
| **Saved** | **1,237** | **~309 (2.0%)** |

## What changed

Three mechanical edits, **description text only**. No schema restructuring, no renames, no signature changes — no tool contract moves.

1. **`"The GTM account ID"` → `"GTM account ID"`**, and the container and workspace equivalents. Repeated 47, 44 and 38 times.
2. **`"This is a safety guard"` dropped** from deletion confirmations — it restates what the field name and the rest of the sentence already say. The publish guard keeps its warning that publishing makes changes live, because that one carries information.
3. **`update_tag` stops repeating the partial-update rule on eleven fields.** Its tool description already says it: *"Only provided fields are changed — all other fields are preserved from the existing tag."* The per-field copies gave the model nothing it did not already have.

`gofmt -l`, `go vet`, `go build`, `go test ./...` all clean.

## I should correct my own estimate

I suggested this would save 2–3k tokens. **It saves 309.** The premise was wrong and the measurement says so.

The reason is worth recording, because it changes what to do next:

| Component | Bytes | Reachable by trimming prose? |
|---|---|---|
| Input schemas | ~30,500 | barely |
| JSON structure + tool names | ~24,000 | no |
| Tool descriptions | ~7,300 | yes — this PR |

Most of the payload is not prose. **Cutting it meaningfully means fewer tools or fewer properties, not shorter sentences.** The lever that actually moves this number is the one deliberately rejected in #89 — multiplexing 50 tools into ~18 action-enum tools — which would save an estimated 5–7k tokens at the cost of precise per-operation schemas.

So: merge this if a free 2% is worth a 40-file diff, and treat the tool-count question as still open and separate. It is not obviously wrong to close this unmerged.

## Deliberately not trimmed

The long `autoEventFilter` and `filter` format explanations in the trigger tools (628 B and 500 B). They are the largest description strings in the codebase, but they teach the model a JSON shape it otherwise gets wrong. This PR was scoped to text carrying no information; those carry a lot.

## Relationship to #89

#89 adds ~30 tools and would push this payload toward 25,000 tokens. This PR does not change that meaningfully — which is itself useful to know before that work starts.