### PR TITLE
fix(ratelimit): key the bucket on the rightmost X-Forwarded-For entry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,7 +82,7 @@ bestpractices/   → go:embed'd markdown rule docs (naming, safe edits, GA4/cons
 **autoEventFilter remapping:** The GTM API silently drops `autoEventFilter` for `linkClick`/`click`/`formSubmission` triggers. `mutations.go` owns the remapping to `filter` — tool handlers don't duplicate this logic.
 
 ### `middleware/`
-- **Rate limiting.** Per-IP token bucket (`golang.org/x/time/rate`). When `TRUST_PROXY=true`, uses `X-Forwarded-For` for client IP; otherwise uses `RemoteAddr` only to prevent spoofing.
+- **Rate limiting.** Per-IP token bucket (`golang.org/x/time/rate`). When `TRUST_PROXY=true`, uses the **rightmost** `X-Forwarded-For` entry for client IP (the one the proxy appended; entries left of it are client-supplied and spoofable); otherwise uses `RemoteAddr` only to prevent spoofing.
 - **Logging.** Structured JSON logs for MCP request/response.
 
 ## Request Lifecycle

--- a/README.md
+++ b/README.md
@@ -501,6 +501,17 @@ examples. Set `TRUST_PROXY=true` for this condition. The rate limiter then uses
 the real IP address of the client from the `X-Forwarded-For` header. If you do
 not set this variable, the rate limiter uses the address of the proxy.
 
+The rate limiter reads the **last** entry in the header. A proxy adds the
+address of its peer to the end of the header. Thus the last entry is the entry
+that your own proxy wrote. The entries before it come from the client, and a
+client can give false values for them. If the header occurs more than one time,
+the server reads the last entry of the last occurrence.
+
+This operation assumes one proxy between the client and the server. If you use
+two proxies, the last entry is the address of the proxy that is nearest to the
+client, not the address of the client. All clients behind that proxy then share
+one limit.
+
 ```bash
 TRUST_PROXY=true
 ```

--- a/middleware/ratelimit.go
+++ b/middleware/ratelimit.go
@@ -86,12 +86,31 @@ func (rl *RateLimiter) cleanup() {
 }
 
 // extractClientIP returns the client IP from the request.
-// When trustProxy is true, the leftmost IP from X-Forwarded-For (set by reverse proxy) is used.
+// When trustProxy is true, the rightmost IP from X-Forwarded-For is used.
 // When false, only RemoteAddr is used to prevent spoofing.
+//
+// The rightmost entry, not the leftmost: a reverse proxy appends the peer
+// address to whatever X-Forwarded-For the client already sent (nginx's
+// $proxy_add_x_forwarded_for), so every entry left of the last one is
+// attacker-controlled. Keying on one would let a client send a fresh value per
+// request and get a fresh bucket each time, defeating the limit entirely. The
+// last entry is the one our own proxy wrote.
+//
+// This assumes exactly one trusted proxy hop in front of the server, which is
+// the deployment. A second proxy would mean skipping that many entries.
 func extractClientIP(r *http.Request, trustProxy bool) string {
 	if trustProxy {
-		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
-			return strings.TrimSpace(strings.SplitN(forwarded, ",", 2)[0])
+		// Joining the header lines rather than reading the first one: a proxy
+		// that appends a line instead of rewriting one leaves the client's own
+		// line first, and RFC 7230 makes repeated field lines equivalent to
+		// one comma-joined line anyway.
+		if forwarded := strings.Join(r.Header.Values("X-Forwarded-For"), ","); forwarded != "" {
+			hops := strings.Split(forwarded, ",")
+			for i := len(hops) - 1; i >= 0; i-- {
+				if hop := strings.TrimSpace(hops[i]); hop != "" {
+					return hop
+				}
+			}
 		}
 	}
 	// RemoteAddr is "ip:port"; strip the port so limiting is per-IP,

--- a/middleware/ratelimit_test.go
+++ b/middleware/ratelimit_test.go
@@ -477,3 +477,174 @@ func TestRateLimiter_DifferentIPsIndependent(t *testing.T) {
 		}
 	}
 }
+
+// The proxy appends the peer address to whatever X-Forwarded-For the client
+// sent, so the leftmost entry is attacker-controlled. A client rotating that
+// value must not get a fresh bucket per request.
+func TestRateLimiter_SpoofedLeftmostXFFCannotEscapeTheBucket(t *testing.T) {
+	rl := NewRateLimiter(1, 1, true)
+	defer rl.Close()
+
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Each request carries a different spoofed leftmost entry; the rightmost
+	// entry is the one our own proxy wrote and is the same every time.
+	send := func(spoofed string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("X-Forwarded-For", spoofed+", 203.0.113.7")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := send("198.51.100.1"); code != http.StatusOK {
+		t.Fatalf("first request: expected status 200, got %d", code)
+	}
+	if code := send("198.51.100.2"); code != http.StatusTooManyRequests {
+		t.Errorf("second request with a rotated leftmost entry: expected status 429, got %d", code)
+	}
+}
+
+// A header that ends in a separator must not collapse the bucket key to the
+// empty string, which would put unrelated clients in one shared bucket.
+func TestRateLimiter_TrailingSeparatorInXFFKeepsTheProxyEntry(t *testing.T) {
+	rl := NewRateLimiter(1, 1, true)
+	defer rl.Close()
+
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	send := func(xff, remoteAddr string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = remoteAddr
+		req.Header.Set("X-Forwarded-For", xff)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// Spends the single token held by 203.0.113.8.
+	if code := send("203.0.113.8, ", "10.0.0.1:1234"); code != http.StatusOK {
+		t.Fatalf("first request: expected status 200, got %d", code)
+	}
+	// A different client, whose header also ends in a separator, must have its
+	// own bucket rather than sharing an empty-string key with the first.
+	if code := send("203.0.113.9, ", "10.0.0.1:5678"); code != http.StatusOK {
+		t.Errorf("unrelated client with a trailing separator: expected status 200, got %d", code)
+	}
+}
+
+// Pinning test: without TRUST_PROXY the header is client-supplied noise and
+// must not affect the bucket. Passes before and after the rightmost fix.
+func TestRateLimiter_XForwardedForIgnoredWhenProxyNotTrusted(t *testing.T) {
+	rl := NewRateLimiter(1, 1, false)
+	defer rl.Close()
+
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	send := func(xff string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "203.0.113.5:1234"
+		req.Header.Set("X-Forwarded-For", xff)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := send("198.51.100.1"); code != http.StatusOK {
+		t.Fatalf("first request: expected status 200, got %d", code)
+	}
+	if code := send("198.51.100.2"); code != http.StatusTooManyRequests {
+		t.Errorf("second request: expected status 429, got %d", code)
+	}
+}
+
+// A proxy that appends a second X-Forwarded-For header line rather than
+// rewriting one leaves the attacker's value in the first line. Reading only
+// the first line would hand the bucket key straight back to the client.
+func TestRateLimiter_SpoofedFirstXFFHeaderLineCannotEscapeTheBucket(t *testing.T) {
+	rl := NewRateLimiter(1, 1, true)
+	defer rl.Close()
+
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	send := func(spoofed string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Add("X-Forwarded-For", spoofed) // the client's own line
+		req.Header.Add("X-Forwarded-For", "203.0.113.7")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := send("198.51.100.1"); code != http.StatusOK {
+		t.Fatalf("first request: expected status 200, got %d", code)
+	}
+	if code := send("198.51.100.2"); code != http.StatusTooManyRequests {
+		t.Errorf("second request with a rotated first header line: expected status 429, got %d", code)
+	}
+}
+
+// A client may legitimately send a multi-value X-Forwarded-For of its own, so
+// after the proxy appends there can be three or more entries. Only the last is
+// trustworthy; the ones the client supplied must not reach the bucket key.
+func TestRateLimiter_RotatingMiddleXFFEntryCannotEscapeTheBucket(t *testing.T) {
+	rl := NewRateLimiter(1, 1, true)
+	defer rl.Close()
+
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	send := func(spoofed string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("X-Forwarded-For", "9.9.9.9, "+spoofed+", 203.0.113.7")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := send("198.51.100.1"); code != http.StatusOK {
+		t.Fatalf("first request: expected status 200, got %d", code)
+	}
+	if code := send("198.51.100.2"); code != http.StatusTooManyRequests {
+		t.Errorf("second request with a rotated middle entry: expected status 429, got %d", code)
+	}
+}
+
+// Without a trusted proxy the key comes from RemoteAddr, which carries an
+// ephemeral source port. Keying on the port would make the bucket
+// per-connection, so a new connection per request would evade the limit.
+func TestRateLimiter_SamePortlessIPSharesABucketAcrossConnections(t *testing.T) {
+	rl := NewRateLimiter(1, 1, false)
+	defer rl.Close()
+
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	send := func(remoteAddr string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = remoteAddr
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := send("203.0.113.9:1111"); code != http.StatusOK {
+		t.Fatalf("first request: expected status 200, got %d", code)
+	}
+	if code := send("203.0.113.9:2222"); code != http.StatusTooManyRequests {
+		t.Errorf("second request from a new source port: expected status 429, got %d", code)
+	}
+}


### PR DESCRIPTION
## The bug

`extractClientIP` takes the **leftmost** `X-Forwarded-For` entry. A reverse proxy *appends* the peer address to whatever the client already sent — nginx's `$proxy_add_x_forwarded_for`, which Nginx Proxy Manager uses — so a request arriving with `X-Forwarded-For: 10.0.0.7` reaches the server as `10.0.0.7, <real client>`. The leftmost value is supplied by the client, not by the proxy.

With `TRUST_PROXY=true`, a client sending a fresh random `X-Forwarded-For` per request gets a brand-new token bucket each time, so rate limiting on `/authorize`, `/token`, `/register` and `/oauth/callback` is bypassable outright. The same rotation also fills the 10,000-entry visitor map with distinct keys, after which `getVisitor` refuses new legitimate clients until the stale-eviction sweep — so it is a denial-of-service vector as well as a bypass.

## The fix

Take the last non-empty entry: the one the proxy wrote.

Three details are load-bearing. Each came from mutating the fixed code and finding the suite still passed:

- **Read every header line, not just the first.** `Header.Get` returns only the first line. A proxy that appends a line rather than rewriting one leaves the client's own line first, handing the bucket key back to the attacker. RFC 7230 makes repeated field lines equivalent to one comma-joined line, so joining before scanning is the same rule applied to the whole header.
- **Scan past empty entries.** With a naive `hops[len-1]`, a header ending in a separator yields `""` as the key and silently puts unrelated clients in one shared bucket.
- **Keep stripping the port from `RemoteAddr`.** That path had no test at all. Returning the address with its port makes the bucket per-connection rather than per-IP — a wider hole than this PR closes, on the **default** `TRUST_PROXY=false` path, needing no proxy and no header. Pinned now.

## Assumption, now documented

Exactly one trusted proxy hop. README and ARCHITECTURE both state it, including what changes with two proxies (the last entry becomes the address of the proxy nearest the client, so everyone behind it shares one limit).

## Tests

Rotated leftmost entry; rotated first header line; rotated middle entry of a three-entry header; trailing separator; same IP on two source ports; and `TRUST_PROXY=false` still ignoring the header. Each was written before the change and watched fail.

`go build`, `go vet`, `go test ./...` clean.

## Provenance

Found by a security review of a sibling MCP server and confirmed by reading this source; the same bug was present in all three. Fixed downstream in `Klartika/gtm-mcp-server#26` and sent here.