### PR TITLE
docs: correct the token store and auto-refresh entries in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,8 +54,8 @@ OAuth 2.1 implementation with two modes:
 | **S2S** | `SERVICE_ACCOUNT_API_KEY` set | Client sends API key as Bearer → server uses Google Service Account for GTM calls |
 
 Key design decisions:
-- **In-memory token store.** No database. Redeployment requires re-auth. Acceptable because tokens are short-lived and the server is single-instance.
-- **Auto-refresh in middleware.** When an access token expires but the refresh token is valid, middleware refreshes the Google token in-place and extends the access token TTL — the client's bearer stays valid without re-auth.
+- **Token store: in memory, optionally file-backed.** No database. By default nothing is persisted, so a redeployment forces every user to re-authenticate. Setting `TOKEN_STORE_PATH` writes issued tokens to a JSON file (mode `0600`, in a directory created `0700`) so sessions survive a restart. It fails closed: if the file cannot be created or read, the server stops at start-up rather than silently discarding sessions. Only issued tokens are persisted — OAuth flow states (10-minute lifetime) and dynamically-registered clients are not, since they are short-lived or re-created by the client on reconnect.
+- **Auto-refresh in middleware.** When an access token expires but the refresh token is valid, middleware refreshes the Google token in-place and extends the access token TTL — the client's bearer stays valid without re-auth. `AUTH_AUTO_REFRESH_MAX_AGE` caps the total age of a silently renewed bearer (default `168h`), so an expired bearer cannot be extended indefinitely.
 - **PKCE required.** No client_secret needed from MCP clients. Code binding via SHA256 challenge.
 - **RFC compliance.** RFC 8414 (server metadata), RFC 9728 (protected resource metadata), RFC 7591 (dynamic client registration).
 


### PR DESCRIPTION
Docs only, no code change.

## What is wrong

`ARCHITECTURE.md` still says, under `auth/` key design decisions:

> - **In-memory token store.** No database. Redeployment requires re-auth. Acceptable because tokens are short-lived and the server is single-instance.

`TOKEN_STORE_PATH` has made that false since the file-backed store landed in #77. README documents the variable in five places, so the two documents currently contradict each other — and the one that is wrong is the one a contributor reads first to understand the design.

The neighbouring auto-refresh bullet describes silent renewal with no mention of a bound, which #85 added.

## The correction

Both rewritten from the code rather than from README:

- **Token store** — both modes; `0600` file in a `0700` directory (`auth/file_token_store.go:44`); fail-closed at start-up rather than silently discarding sessions; and that only issued tokens are persisted, since flow states and dynamically-registered clients are deliberately excluded (`auth/file_token_store.go:24-27`).
- **Auto-refresh** — adds the `AUTH_AUTO_REFRESH_MAX_AGE` cap and its `168h` default (`config/config.go:79`).

## Provenance

Noticed while adding an unrelated bullet to the same list downstream. Tracked as `Klartika/gtm-mcp-server#28`.