### PR TITLE
feat(gtm): begin official API parity with version headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,7 @@ triggers, use `filterJson` because GTM ignores `autoEventFilter`.
 |------|-------------|
 | `get_workspace_status` | Gives the changes and the merge conflicts before a version |
 | `list_versions` | Gives all the container versions with the counts of the items |
+| `get_latest_version_header` | Gets the latest container version header (which may differ from the live version) |
 | `create_version` | Creates a version from the changes in a workspace |
 | `publish_version` | Publishes a version. Asks for approval |
 

--- a/gtm/tool_get_latest_version_header.go
+++ b/gtm/tool_get_latest_version_header.go
@@ -1,0 +1,71 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+type LatestVersionHeaderOutput struct {
+	Version VersionInfo `json:"version"`
+}
+
+func registerGetLatestVersionHeader(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_latest_version_header",
+		Description: "Get the latest container version header. The latest version may differ from the published live version.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListVersionsInput) (*mcp.CallToolResult, LatestVersionHeaderOutput, error) {
+		if input.AccountID == "" || input.ContainerID == "" {
+			return nil, LatestVersionHeaderOutput{}, fmt.Errorf("accountId and containerId are required")
+		}
+		client, err := getClient(ctx)
+		if err != nil {
+			return nil, LatestVersionHeaderOutput{}, err
+		}
+		version, err := client.LatestVersionHeader(ctx, BuildContainerPath(input.AccountID, input.ContainerID))
+		if err != nil {
+			return nil, LatestVersionHeaderOutput{}, err
+		}
+		return nil, LatestVersionHeaderOutput{Version: version}, nil
+	})
+}
+
+func versionHeaderInfo(v *tagmanager.ContainerVersionHeader) VersionInfo {
+	return VersionInfo{
+		VersionID: v.ContainerVersionId, Name: v.Name, Deleted: v.Deleted,
+		NumTags: v.NumTags, NumTriggers: v.NumTriggers, NumVariables: v.NumVariables,
+		NumCustomTemplates: v.NumCustomTemplates, Path: v.Path,
+	}
+}
+
+func (c *Client) LatestVersionHeader(ctx context.Context, parent string) (VersionInfo, error) {
+	header, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ContainerVersionHeader, error) {
+		return c.Service.Accounts.Containers.VersionHeaders.Latest(parent).Context(ctx).Do()
+	})
+	if err != nil {
+		return VersionInfo{}, mapGoogleError(err)
+	}
+	return versionHeaderInfo(header), nil
+}
+
+func (c *Client) ListVersionHeaders(ctx context.Context, parent string) ([]VersionInfo, error) {
+	versions := make([]VersionInfo, 0)
+	pageToken := ""
+	for {
+		response, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListContainerVersionsResponse, error) {
+			return c.Service.Accounts.Containers.VersionHeaders.List(parent).PageToken(pageToken).Context(ctx).Do()
+		})
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		for _, header := range response.ContainerVersionHeader {
+			versions = append(versions, versionHeaderInfo(header))
+		}
+		pageToken = response.NextPageToken
+		if pageToken == "" {
+			return versions, nil
+		}
+	}
+}

--- a/gtm/tool_list_versions.go
+++ b/gtm/tool_list_versions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	tagmanager "google.golang.org/api/tagmanager/v2"
 )
 
 // ListVersionsInput is the input for list_versions tool.
@@ -48,27 +47,9 @@ func registerListVersions(server *mcp.Server) {
 
 		parent := fmt.Sprintf("accounts/%s/containers/%s", input.AccountID, input.ContainerID)
 
-		resp, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListContainerVersionsResponse, error) {
-			return client.Service.Accounts.Containers.VersionHeaders.List(parent).Context(ctx).Do()
-		})
+		versions, err := client.ListVersionHeaders(ctx, parent)
 		if err != nil {
-			return nil, ListVersionsOutput{}, mapGoogleError(err)
-		}
-
-		versions := make([]VersionInfo, 0)
-		if resp.ContainerVersionHeader != nil {
-			for _, v := range resp.ContainerVersionHeader {
-				versions = append(versions, VersionInfo{
-					VersionID:          v.ContainerVersionId,
-					Name:               v.Name,
-					Deleted:            v.Deleted,
-					NumTags:            v.NumTags,
-					NumTriggers:        v.NumTriggers,
-					NumVariables:       v.NumVariables,
-					NumCustomTemplates: v.NumCustomTemplates,
-					Path:               v.Path,
-				})
-			}
+			return nil, ListVersionsOutput{}, err
 		}
 
 		return nil, ListVersionsOutput{

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -27,6 +27,7 @@ func RegisterTools(server *mcp.Server) {
 	registerListTemplates(server)
 	registerGetTemplate(server)
 	registerListVersions(server)
+	registerGetLatestVersionHeader(server)
 
 	// Write operations
 	registerCreateTag(server)

--- a/gtm/version_headers_test.go
+++ b/gtm/version_headers_test.go
@@ -1,0 +1,109 @@
+package gtm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/option"
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+func versionTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	service, err := tagmanager.NewService(context.Background(), option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Client{Service: service}
+}
+
+func TestLatestVersionHeader(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/version_headers:latest" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"containerVersionId":"8","name":"Draft snapshot","numTags":"3","path":"accounts/1/containers/2/versions/8"}`)
+	})
+	got, err := client.LatestVersionHeader(context.Background(), "accounts/1/containers/2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.VersionID != "8" || got.NumTags != "3" || got.Name != "Draft snapshot" {
+		t.Fatalf("unexpected header: %+v", got)
+	}
+}
+
+func TestListVersionHeadersPagination(t *testing.T) {
+	calls := 0
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/version_headers" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			fmt.Fprint(w, `{"containerVersionHeader":[{"containerVersionId":"1"}],"nextPageToken":"page2"}`)
+		case "page2":
+			fmt.Fprint(w, `{"containerVersionHeader":[{"containerVersionId":"2"}]}`)
+		default:
+			t.Error("unexpected page token")
+			w.WriteHeader(400)
+		}
+	})
+	got, err := client.ListVersionHeaders(context.Background(), "accounts/1/containers/2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || len(got) != 2 || got[0].VersionID != "1" || got[1].VersionID != "2" {
+		t.Fatalf("calls=%d versions=%+v", calls, got)
+	}
+}
+
+func TestVersionHeaderErrors(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"code":404,"message":"missing container"}}`)
+	})
+	if _, err := client.LatestVersionHeader(context.Background(), "accounts/1/containers/2"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("latest: %v", err)
+	}
+	if _, err := client.ListVersionHeaders(context.Background(), "accounts/1/containers/2"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("list: %v", err)
+	}
+}
+
+func TestListVersionHeadersEmpty(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	})
+	got, err := client.ListVersionHeaders(context.Background(), "accounts/1/containers/2")
+	if err != nil || got == nil || len(got) != 0 {
+		t.Fatalf("versions=%v err=%v", got, err)
+	}
+}
+
+func TestListVersionHeadersLaterPageError(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("pageToken") == "" {
+			fmt.Fprint(w, `{"containerVersionHeader":[{"containerVersionId":"1"}],"nextPageToken":"next"}`)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"error":{"code":404,"message":"container removed"}}`)
+		}
+	})
+	got, err := client.ListVersionHeaders(context.Background(), "accounts/1/containers/2")
+	if !errors.Is(err, ErrNotFound) || got != nil {
+		t.Fatalf("partial results reported as complete: %v, %v", got, err)
+	}
+}

--- a/llms.txt
+++ b/llms.txt
@@ -87,7 +87,8 @@ Always discover IDs by listing — never guess or hardcode them.
 | `get_workspace_status` | Check pending changes and conflicts before versioning |
 | `create_version` | Create a version from workspace changes |
 | `publish_version` | Publish a version to go live (requires `confirm: true`) |
-| `list_versions` | List all container versions |
+| `list_versions` | List all container version headers, across all pages |
+| `get_latest_version_header` | Get the latest version header; latest is not necessarily live |
 
 ### Templates
 | Tool | Purpose |


### PR DESCRIPTION
Add `get_latest_version_header` and fix `list_versions` to follow every result page. Existing tool names and output shapes remain compatible, and the new tool explicitly distinguishes latest from published/live.

This is the first implementation slice of API coverage work discussed in #89. Planning documents are maintained locally and are not part of this PR.

Validation: full Go suite and go vet pass. Request-level tests cover latest lookup, pagination, empty responses, missing containers, and errors on subsequent pages. Live validation against a container with saved versions remains outstanding. No deployment or version bump is included.
