### PR TITLE
fix(build): align Docker builder with Go 1.26 requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage (using Google mirror to avoid Docker Hub rate limits)
-FROM mirror.gcr.io/library/golang:1.25-alpine AS builder
+FROM mirror.gcr.io/library/golang:1.26-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Deployment failed at go mod download: go.mod requires Go 1.26.0, but the Docker builder ran Go 1.25 with GOTOOLCHAIN=local. Use the Go 1.26 Alpine builder image.

Validation: local go build, go vet, and staticcheck pass with Go 1.26.8; all GitHub CI checks pass. The corrected image built successfully on the VPS and Docker Compose recreated the service. The public health endpoint returns 200 and unauthenticated MCP requests return 401 with an OAuth challenge. The previous image is retained locally on the VPS as a rollback tag.
