### PR TITLE
fix: derive runtime version from server metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,13 @@ limit.
 The server writes the log event `auth_auto_refresh_capped` for each refusal.
 The event contains the client ID and the age of the refused sequence.
 
+### Runtime version
+
+The MCP handshake and `/health` read their version from `server.json`, embedded
+when the binary is built. Update its `version` field for a release, then rebuild
+and deploy. No separate version edit in Go code is needed. Changing a JSON file
+beside an already-running binary does not change that binary’s version.
+
 ### Google Cloud Setup
 
 1. Go to the [Google Cloud Console](https://console.cloud.google.com/).

--- a/main.go
+++ b/main.go
@@ -24,10 +24,7 @@ import (
 //go:embed llms.txt
 var llmsTxt string
 
-const (
-	serverName    = "gtm-mcp-server"
-	serverVersion = "1.10.0"
-)
+const serverName = "gtm-mcp-server"
 
 func main() {
 	// Set up structured logging to stderr (stdout is reserved for MCP in stdio mode)
@@ -35,6 +32,12 @@ func main() {
 		Level: slog.LevelInfo,
 	}))
 	slog.SetDefault(logger)
+
+	serverVersion, err := parseServerVersion(serverMetadata)
+	if err != nil {
+		logger.Error("invalid embedded server metadata", "error", err)
+		os.Exit(1)
+	}
 
 	// Load configuration
 	cfg, err := config.Load()

--- a/version.go
+++ b/version.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Embed registry metadata so standalone binaries and Docker images use the
+// same version without depending on files in the runtime working directory.
+//
+//go:embed server.json
+var serverMetadata []byte
+
+func parseServerVersion(data []byte) (string, error) {
+	var metadata struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return "", fmt.Errorf("parse server.json: %w", err)
+	}
+	if strings.TrimSpace(metadata.Version) == "" {
+		return "", fmt.Errorf("server.json version must not be empty")
+	}
+	return metadata.Version, nil
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestServerVersionMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name, data, want string
+		invalid          bool
+	}{
+		{"version", `{"version":"2.3.4","name":"example/server"}`, "2.3.4", false},
+		{"prerelease", `{"version":"2.3.4-rc.1"}`, "2.3.4-rc.1", false},
+		{"malformed", `{`, "", true},
+		{"missing", `{}`, "", true},
+		{"empty", `{"version":""}`, "", true},
+		{"whitespace", `{"version":"  "}`, "", true},
+		{"wrong type", `{"version":123}`, "", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseServerVersion([]byte(tt.data))
+			if (err != nil) != tt.invalid || got != tt.want {
+				t.Fatalf("version=%q err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestEmbeddedServerVersion(t *testing.T) {
+	// The production metadata must also pass validation; no duplicated version
+	// literal here to become stale at the next release.
+	if _, err := parseServerVersion(serverMetadata); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
`main.go` previously duplicated the release version, so `server.json` could be updated while `/health` and the MCP handshake continued reporting an older value. This embeds `server.json` at build time and validates its version during startup, giving releases one version field to maintain while preserving standalone binary and Docker behavior.

Validation:
- `go test ./... -count=1 -timeout=120s`
- `go build -o /tmp/gtm-mcp-versioned .`
- standalone launch from `/tmp`, where `/health` and MCP `initialize` both reported `1.10.1`
