### PR TITLE
perf: establish MCP tool schema budget

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,6 +182,7 @@ go test ./...          # All tests
 go test ./auth/ -v     # Auth package (OAuth flow, middleware, token store)
 go test ./gtm/ -v      # GTM package (error mapping)
 go test ./middleware/   # Rate limiting
+go run ./cmd/tool-schema-report  # Tool count, payload size, and largest schemas
 ```
 
 Test coverage focuses on:
@@ -191,6 +192,11 @@ Test coverage focuses on:
 - Error mapping (Google API errors → user-friendly messages)
 
 Integration tests (`auth/integration_test.go`) run the full OAuth flow with a mock Google token server.
+
+The default serialized `tools/list` result has an 80 KB regression budget.
+Parity PRs report their byte delta with `tool-schema-report`. If the default
+surface reaches that limit, introduce configurable tool groups before adding
+more tools instead of silently increasing every client's context cost.
 
 ## Key Invariants
 

--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ gtm://best-practices/naming-organization    # Names, folders, and unused items
 gtm://best-practices/safe-edit-workflow     # Workspace, difference, version, publication
 gtm://best-practices/ga4-consent            # GA4 patterns and consent mode v2
 gtm://best-practices/server-side            # Clients, transformations, PII, first-party domains
+gtm://best-practices/tool-input-formats      # JSON formats used by mutation tools
 ```
 
 ### Prompts

--- a/cmd/tool-schema-report/main.go
+++ b/cmd/tool-schema-report/main.go
@@ -1,0 +1,113 @@
+// Command tool-schema-report measures the MCP tool definitions sent to clients.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"gtm-mcp-server/gtm"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type toolSize struct {
+	name              string
+	bytes             int
+	inputSchemaBytes  int
+	outputSchemaBytes int
+	descriptionBytes  int
+}
+
+func main() {
+	top := flag.Int("top", 10, "number of largest tool definitions to print")
+	flag.Parse()
+	if *top < 0 {
+		log.Fatal("-top must be zero or greater")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "tool-schema-report",
+		Version: "development",
+	}, nil)
+	gtm.RegisterTools(server)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		log.Fatalf("connect server: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "tool-schema-report",
+		Version: "development",
+	}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		log.Fatalf("connect client: %v", err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		log.Fatalf("list tools: %v", err)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		log.Fatalf("marshal tools/list result: %v", err)
+	}
+
+	sizes := make([]toolSize, 0, len(result.Tools))
+	for _, tool := range result.Tools {
+		definition, err := json.Marshal(tool)
+		if err != nil {
+			log.Fatalf("marshal tool %q: %v", tool.Name, err)
+		}
+		inputSchema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			log.Fatalf("marshal input schema for %q: %v", tool.Name, err)
+		}
+		outputSchema, err := json.Marshal(tool.OutputSchema)
+		if err != nil {
+			log.Fatalf("marshal output schema for %q: %v", tool.Name, err)
+		}
+		sizes = append(sizes, toolSize{
+			name:              tool.Name,
+			bytes:             len(definition),
+			inputSchemaBytes:  len(inputSchema),
+			outputSchemaBytes: len(outputSchema),
+			descriptionBytes:  len(tool.Description),
+		})
+	}
+	sort.Slice(sizes, func(i, j int) bool {
+		if sizes[i].bytes == sizes[j].bytes {
+			return sizes[i].name < sizes[j].name
+		}
+		return sizes[i].bytes > sizes[j].bytes
+	})
+
+	fmt.Printf("tools: %d\n", len(result.Tools))
+	fmt.Printf("tools/list result bytes: %d\n", len(payload))
+	fmt.Printf("estimated tokens at 4 bytes/token: %d\n", (len(payload)+3)/4)
+	fmt.Println("largest tool definitions (total, input schema, output schema, description):")
+	for i, size := range sizes {
+		if i >= *top {
+			break
+		}
+		fmt.Printf("%d\t%d\t%d\t%d\t%s\n",
+			size.bytes,
+			size.inputSchemaBytes,
+			size.outputSchemaBytes,
+			size.descriptionBytes,
+			size.name,
+		)
+	}
+}

--- a/gtm/bestpractices/bestpractices_test.go
+++ b/gtm/bestpractices/bestpractices_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestTopicsReturnsAllTopics(t *testing.T) {
 	topics := Topics()
-	expected := []string{"index", "naming-organization", "safe-edit-workflow", "ga4-consent", "server-side"}
+	expected := []string{"index", "naming-organization", "safe-edit-workflow", "ga4-consent", "server-side", "tool-input-formats"}
 	if len(topics) != len(expected) {
 		t.Fatalf("expected %d topics, got %d: %v", len(expected), len(topics), topics)
 	}

--- a/gtm/bestpractices/docs/index.md
+++ b/gtm/bestpractices/docs/index.md
@@ -13,6 +13,7 @@ convention.
 | safe-edit-workflow | gtm://best-practices/safe-edit-workflow | How to make changes safely: workspace → diff → version → publish |
 | ga4-consent | gtm://best-practices/ga4-consent | GA4 tag patterns, consent mode v2, duplicate measurement |
 | server-side | gtm://best-practices/server-side | Server containers: clients, transformations, PII, first-party domains |
+| tool-input-formats | gtm://best-practices/tool-input-formats | JSON parameter, sequencing, trigger, transformation, and template input shapes |
 
 ## How to apply
 
@@ -20,7 +21,8 @@ convention.
 2. Before creating entities: read naming-organization and name accordingly.
 3. When working with GA4 or consent tools: read ga4-consent.
 4. When the container usage context is "server": read server-side.
-5. When auditing: score the container against every topic (pass / warn / fail
+5. Before passing JSON strings to mutation tools: read tool-input-formats.
+6. When auditing: score the container against every topic (pass / warn / fail
    per rule) and propose concrete fixes.
 
 Existing conventions in a container take precedence over these rules — match

--- a/gtm/bestpractices/docs/tool-input-formats.md
+++ b/gtm/bestpractices/docs/tool-input-formats.md
@@ -1,0 +1,72 @@
+# Tool Input Formats
+
+Several GTM tools accept JSON as a string because Google models parameters as
+recursive `type`/`key`/`value` objects. Use the shapes below instead of guessing
+the wire format.
+
+## Parameters
+
+A scalar parameter has `type`, `key`, and `value` fields:
+
+```json
+[{"type":"template","key":"measurementId","value":"G-XXXXXXX"}]
+```
+
+Use `list` or `map` instead of `value` for nested parameters. When an update tool
+says a JSON field can be omitted, omission preserves the existing value and `[]`
+clears it.
+
+## Tag sequencing
+
+Setup and teardown tags are arrays referencing a tag name:
+
+```json
+[{"tagName":"12","stopOnSetupFailure":true}]
+```
+
+```json
+[{"tagName":"34","stopTeardownOnFailure":false}]
+```
+
+## Trigger conditions
+
+Conditions support `equals`, `contains`, `doesNotContain`, `startsWith`,
+`endsWith`, and `matchRegex`. Each condition contains a parameter array with
+`arg0` for the variable and `arg1` for the comparison value.
+
+For `linkClick`, `click`, and `formSubmission`, Google silently drops
+`autoEventFilter`; the server remaps those conditions to `filter`. A trigger
+group uses this parameter shape:
+
+```json
+[{"key":"triggerIds","type":"list","list":[{"type":"triggerReference","value":"TRIGGER_ID"}]}]
+```
+
+## Transformations
+
+Transformation types and their table fields are:
+
+- `tf_allow_params`: `allowedParamsTable`, column `allowedParams`
+- `tf_exclude_params`: `excludedParamsTable`, column `excludedParams`
+- `tf_augment_event`: `augmentEventTable`, columns `paramName` and `paramValue`
+
+The common fields are `matchingConditionsEnabled`, `allTagsExcept`,
+`affectedTags`, `affectedTagTypes`, and `matchingConditionsTable`.
+
+Example exclusion parameters:
+
+```json
+[
+  {"key":"excludedParamsTable","type":"list","list":[{"type":"map","map":[{"key":"excludedParams","type":"template","value":"x-fb-ck-fbp"}]}]},
+  {"key":"matchingConditionsEnabled","type":"boolean","value":"false"},
+  {"key":"allTagsExcept","type":"boolean","value":"false"},
+  {"key":"affectedTags","type":"list"},
+  {"key":"affectedTagTypes","type":"list"}
+]
+```
+
+## Custom templates
+
+The template `name` field is an internal identifier. Change the visible name by
+editing `displayName` inside the `___INFO___` section of `templateData`. Updating
+a Gallery template can detach it from the Gallery source.

--- a/gtm/resources.go
+++ b/gtm/resources.go
@@ -88,7 +88,7 @@ func RegisterResources(server *mcp.Server) {
 	// gtm://best-practices - configuration best-practices index (static, no auth)
 	server.AddResource(&mcp.Resource{
 		Name:        "GTM Best Practices",
-		Description: "Opinionated rules for good GTM configuration: naming, safe edits, GA4/consent, server-side",
+		Description: "GTM configuration guidance: naming, safe edits, GA4/consent, server-side, and tool input formats",
 		MIMEType:    "text/markdown",
 		URI:         uriBestPractices,
 	}, handleBestPracticesIndexResource)
@@ -96,7 +96,7 @@ func RegisterResources(server *mcp.Server) {
 	// gtm://best-practices/{topic} - individual best-practices document
 	server.AddResourceTemplate(&mcp.ResourceTemplate{
 		Name:        "GTM Best Practices Topic",
-		Description: "A single best-practices document: naming-organization, safe-edit-workflow, ga4-consent, or server-side",
+		Description: "A best-practices topic, including safe-edit workflows and tool input formats",
 		MIMEType:    "text/markdown",
 		URITemplate: uriBestPracticesTopic,
 	}, handleBestPracticesTopicResource)

--- a/gtm/resources_bestpractices_test.go
+++ b/gtm/resources_bestpractices_test.go
@@ -37,6 +37,7 @@ func TestBestPracticesTopicResource(t *testing.T) {
 		{"safe-edit-workflow", "Safe-Edit Workflow"},
 		{"ga4-consent", "GA4 and Consent"},
 		{"server-side", "Server-Side Container"},
+		{"tool-input-formats", "Tool Input Formats"},
 	}
 	for _, tt := range tests {
 		req := &mcp.ReadResourceRequest{

--- a/gtm/tool_create_tag.go
+++ b/gtm/tool_create_tag.go
@@ -18,9 +18,9 @@ type CreateTagInput struct {
 	Type               string   `json:"type" jsonschema:"description:Tag type (e.g. gaawe for GA4, html for Custom HTML)"`
 	FiringTriggerIDs   []string `json:"firingTriggerIds" jsonschema:"description:Array of trigger IDs that fire this tag"`
 	BlockingTriggerIDs []string `json:"blockingTriggerIds,omitempty" jsonschema:"description:Array of trigger IDs that block this tag (optional)"`
-	ParametersJSON     string   `json:"parametersJson,omitempty" jsonschema:"description:Tag parameters as JSON array (optional). Each parameter: {type, key, value} or {type, key, list/map}"`
-	SetupTagJSON       string   `json:"setupTagJson,omitempty" jsonschema:"description:Setup tag sequencing as JSON array (optional). Each element: {tagName: string, stopOnSetupFailure: bool}. The setup tag fires before this tag."`
-	TeardownTagJSON    string   `json:"teardownTagJson,omitempty" jsonschema:"description:Teardown tag sequencing as JSON array (optional). Each element: {tagName: string, stopTeardownOnFailure: bool}. The teardown tag fires after this tag."`
+	ParametersJSON     string   `json:"parametersJson,omitempty" jsonschema:"description:JSON parameters; see gtm://best-practices/tool-input-formats"`
+	SetupTagJSON       string   `json:"setupTagJson,omitempty" jsonschema:"description:JSON setup sequence; see gtm://best-practices/tool-input-formats"`
+	TeardownTagJSON    string   `json:"teardownTagJson,omitempty" jsonschema:"description:JSON teardown sequence; see gtm://best-practices/tool-input-formats"`
 	ConsentStatus      string   `json:"consentStatus,omitempty" jsonschema:"description:Consent status: notSet (default)\\, notNeeded (no consent required)\\, needed (requires consent types to be granted before firing)."`
 	ConsentTypes       string   `json:"consentTypes,omitempty" jsonschema:"description:Comma-separated consent types when consentStatus is needed (e.g. ad_storage\\,analytics_storage\\,ad_user_data\\,ad_personalization). Ignored when consentStatus is notSet or notNeeded."`
 	Notes              string   `json:"notes,omitempty" jsonschema:"description:Tag notes (optional)"`

--- a/gtm/tool_create_transformation.go
+++ b/gtm/tool_create_transformation.go
@@ -13,8 +13,8 @@ type CreateTransformationInput struct {
 	ContainerID    string `json:"containerId" jsonschema:"description:The GTM container ID"`
 	WorkspaceID    string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
 	Name           string `json:"name" jsonschema:"description:Transformation name"`
-	Type           string `json:"type" jsonschema:"description:Transformation type. Valid values: tf_exclude_params (exclude parameters from tags), tf_allow_params (allow only specified parameters), tf_augment_event (add/modify event parameters)"`
-	ParametersJSON string `json:"parametersJson,omitempty" jsonschema:"description:Transformation parameters as JSON array (optional). Each parameter: {type, key, value} or {type, key, list/map}"`
+	Type           string `json:"type" jsonschema:"description:One of tf_exclude_params, tf_allow_params, or tf_augment_event"`
+	ParametersJSON string `json:"parametersJson,omitempty" jsonschema:"description:JSON parameter array; see gtm://best-practices/tool-input-formats"`
 	Notes          string `json:"notes,omitempty" jsonschema:"description:Transformation notes (optional)"`
 }
 
@@ -63,24 +63,7 @@ func registerCreateTransformation(server *mcp.Server) {
 	}
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "create_transformation",
-		Description: `Create a new transformation in a GTM workspace (server-side containers only).
-
-Type must be one of: tf_exclude_params, tf_allow_params, tf_augment_event.
-
-Each type uses a different table key and column names in parametersJson:
-- tf_allow_params: "allowedParamsTable" with column "allowedParams"
-- tf_exclude_params: "excludedParamsTable" with column "excludedParams"
-- tf_augment_event: "augmentEventTable" with columns "paramName" and "paramValue"
-
-Common parameters shared by all types:
-- matchingConditionsEnabled (boolean) — whether conditions must match
-- allTagsExcept (boolean) — if true, apply to all tags except listed ones
-- affectedTags (list of maps with tagReference) — specific tags to target
-- affectedTagTypes (list of maps with tagType + tagTypeExceptions) — tag types to target
-- matchingConditionsTable (list of maps with variableName, variableReference, expressionType, expressionValue)
-
-Example for tf_exclude_params:
-[{"key":"excludedParamsTable","type":"list","list":[{"type":"map","map":[{"key":"excludedParams","type":"template","value":"x-fb-ck-fbp"}]}]},{"key":"matchingConditionsEnabled","type":"boolean","value":"false"},{"key":"allTagsExcept","type":"boolean","value":"false"},{"key":"affectedTags","type":"list"},{"key":"affectedTagTypes","type":"list"}]`,
+		Name:        "create_transformation",
+		Description: "Create a transformation in a server-side workspace. Read gtm://best-practices/tool-input-formats for parameter table shapes.",
 	}, handler)
 }

--- a/gtm/tool_create_trigger.go
+++ b/gtm/tool_create_trigger.go
@@ -14,9 +14,9 @@ type CreateTriggerInput struct {
 	WorkspaceID           string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
 	Name                  string `json:"name" jsonschema:"description:Trigger name"`
 	Type                  string `json:"type" jsonschema:"description:Trigger type (e.g. pageview, customEvent, linkClick, formSubmission, timer)"`
-	FilterJSON            string `json:"filterJson,omitempty" jsonschema:"description:Filter conditions as JSON array for pageview triggers. Condition types: equals\\, contains\\, doesNotContain\\, startsWith\\, endsWith\\, matchRegex. Each condition has type and parameter array with arg0 (variable) and arg1 (value). (optional)"`
-	AutoEventFilterJSON   string `json:"autoEventFilterJson,omitempty" jsonschema:"description:Auto-event filter as JSON array for click/form triggers. Condition types: equals\\, contains\\, doesNotContain\\, startsWith\\, endsWith\\, matchRegex. NOTE: for linkClick\\, click\\, and formSubmission triggers the GTM API silently drops autoEventFilter — use filterJson instead for these types. (optional)"`
-	CustomEventFilterJSON string `json:"customEventFilterJson,omitempty" jsonschema:"description:Custom event filter as JSON array for customEvent triggers. Condition types: equals\\, contains\\, doesNotContain\\, startsWith\\, endsWith\\, matchRegex. REQUIRED for customEvent type. Must contain exactly one condition matching the event name."`
+	FilterJSON            string `json:"filterJson,omitempty" jsonschema:"description:JSON conditions; see gtm://best-practices/tool-input-formats"`
+	AutoEventFilterJSON   string `json:"autoEventFilterJson,omitempty" jsonschema:"description:JSON auto-event conditions; see gtm://best-practices/tool-input-formats"`
+	CustomEventFilterJSON string `json:"customEventFilterJson,omitempty" jsonschema:"description:JSON custom-event conditions; required for customEvent; see gtm://best-practices/tool-input-formats"`
 	EventNameJSON         string `json:"eventNameJson,omitempty" jsonschema:"description:Event name as JSON object {type, value} for timer triggers (optional)"`
 	Notes                 string `json:"notes,omitempty" jsonschema:"description:Trigger notes (optional)"`
 }
@@ -103,6 +103,6 @@ func registerCreateTrigger(server *mcp.Server) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "create_trigger",
-		Description: "Create a new trigger in a GTM workspace. Common types: pageview, customEvent, linkClick, formSubmission, timer, scrollDepth. Filter condition types: equals, contains, doesNotContain, startsWith, endsWith, matchRegex. The doesNotContain type is automatically transformed to a negated contains condition for the GTM API.",
+		Description: "Create a workspace trigger. Read gtm://best-practices/tool-input-formats for condition and trigger-group shapes.",
 	}, handler)
 }

--- a/gtm/tool_schema_budget_test.go
+++ b/gtm/tool_schema_budget_test.go
@@ -1,0 +1,47 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Keep the default tool surface below the threshold where the parity roadmap
+// requires configurable tool groups. Run cmd/tool-schema-report for details.
+func TestToolSchemaBudget(t *testing.T) {
+	const maxBytes = 80_000
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "schema-test", Version: "1"}, nil)
+	RegisterTools(server)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "schema-test", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) > maxBytes {
+		t.Fatalf("tools/list result is %d bytes, above %d; run go run ./cmd/tool-schema-report and introduce configurable tool groups", len(payload), maxBytes)
+	}
+}

--- a/gtm/tool_update_tag.go
+++ b/gtm/tool_update_tag.go
@@ -19,9 +19,9 @@ type UpdateTagInput struct {
 	Type               string   `json:"type,omitempty" jsonschema:"description:Tag type. If omitted\\, existing type is preserved."`
 	FiringTriggerIDs   []string `json:"firingTriggerIds,omitempty" jsonschema:"description:Array of trigger IDs that fire this tag. If omitted\\, existing triggers are preserved."`
 	BlockingTriggerIDs []string `json:"blockingTriggerIds,omitempty" jsonschema:"description:Array of trigger IDs that block this tag. If omitted\\, existing blocking triggers are preserved."`
-	ParametersJSON     string   `json:"parametersJson,omitempty" jsonschema:"description:Tag parameters as JSON array. If omitted\\, existing parameters (pixel IDs\\, measurement IDs\\, etc.) are preserved."`
-	SetupTagJSON       string   `json:"setupTagJson,omitempty" jsonschema:"description:Setup tag sequencing as JSON array. Each element: {tagName: string\\, stopOnSetupFailure: bool}. Pass [] to clear. If omitted\\, existing setup tags are preserved."`
-	TeardownTagJSON    string   `json:"teardownTagJson,omitempty" jsonschema:"description:Teardown tag sequencing as JSON array. Each element: {tagName: string\\, stopTeardownOnFailure: bool}. Pass [] to clear. If omitted\\, existing teardown tags are preserved."`
+	ParametersJSON     string   `json:"parametersJson,omitempty" jsonschema:"description:JSON parameters; omit to preserve; see gtm://best-practices/tool-input-formats"`
+	SetupTagJSON       string   `json:"setupTagJson,omitempty" jsonschema:"description:JSON setup sequence; omit to preserve\\, [] to clear; see gtm://best-practices/tool-input-formats"`
+	TeardownTagJSON    string   `json:"teardownTagJson,omitempty" jsonschema:"description:JSON teardown sequence; omit to preserve\\, [] to clear; see gtm://best-practices/tool-input-formats"`
 	ConsentStatus      string   `json:"consentStatus,omitempty" jsonschema:"description:Consent status: notSet (default/clear)\\, notNeeded (no consent required)\\, needed (requires consent types to be granted before firing). If omitted\\, existing consent settings are preserved."`
 	ConsentTypes       string   `json:"consentTypes,omitempty" jsonschema:"description:Comma-separated consent types when consentStatus is needed (e.g. ad_storage\\,analytics_storage\\,ad_user_data\\,ad_personalization). Ignored when consentStatus is notSet or notNeeded."`
 	Notes              string   `json:"notes,omitempty" jsonschema:"description:Tag notes. If omitted\\, existing notes are preserved."`

--- a/gtm/tool_update_transformation.go
+++ b/gtm/tool_update_transformation.go
@@ -15,8 +15,8 @@ type UpdateTransformationInput struct {
 	WorkspaceID      string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
 	TransformationID string `json:"transformationId" jsonschema:"description:The transformation ID to update"`
 	Name             string `json:"name" jsonschema:"description:Transformation name"`
-	Type             string `json:"type,omitempty" jsonschema:"description:Transformation type (optional). Valid values: tf_exclude_params, tf_allow_params, tf_augment_event"`
-	ParametersJSON   string `json:"parametersJson,omitempty" jsonschema:"description:Transformation parameters as JSON array (optional)"`
+	Type             string `json:"type,omitempty" jsonschema:"description:One of tf_exclude_params, tf_allow_params, or tf_augment_event"`
+	ParametersJSON   string `json:"parametersJson,omitempty" jsonschema:"description:JSON parameter array; see gtm://best-practices/tool-input-formats"`
 	Notes            string `json:"notes,omitempty" jsonschema:"description:Transformation notes (optional)"`
 }
 
@@ -71,12 +71,7 @@ func registerUpdateTransformation(server *mcp.Server) {
 	}
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "update_transformation",
-		Description: `Update an existing transformation. Automatically handles fingerprint for concurrency control. Server-side containers only.
-
-Type must be one of: tf_exclude_params, tf_allow_params, tf_augment_event. Table key and columns per type:
-- tf_allow_params: "allowedParamsTable" with column "allowedParams"
-- tf_exclude_params: "excludedParamsTable" with column "excludedParams"
-- tf_augment_event: "augmentEventTable" with columns "paramName" and "paramValue"`,
+		Name:        "update_transformation",
+		Description: "Update a server-side transformation with automatic fingerprint handling. See gtm://best-practices/tool-input-formats.",
 	}, handler)
 }

--- a/gtm/tool_update_trigger.go
+++ b/gtm/tool_update_trigger.go
@@ -16,10 +16,10 @@ type UpdateTriggerInput struct {
 	TriggerID             string `json:"triggerId" jsonschema:"description:The trigger ID to update"`
 	Name                  string `json:"name" jsonschema:"description:Trigger name"`
 	Type                  string `json:"type" jsonschema:"description:Trigger type (e.g. pageview, customEvent, linkClick, triggerGroup)"`
-	FilterJSON            string `json:"filterJson,omitempty" jsonschema:"description:Omit to preserve; pass [] to clear. Filter conditions as JSON array for pageview triggers. Condition types: equals\\, contains\\, doesNotContain\\, startsWith\\, endsWith\\, matchRegex. Each condition has type and parameter array with arg0 (variable) and arg1 (value). (optional)"`
-	AutoEventFilterJSON   string `json:"autoEventFilterJson,omitempty" jsonschema:"description:Omit to preserve; pass [] to clear. Auto-event filter as JSON array for click/form triggers. Condition types: equals\\, contains\\, doesNotContain\\, startsWith\\, endsWith\\, matchRegex. NOTE: for linkClick\\, click\\, and formSubmission triggers the GTM API silently drops autoEventFilter — use filterJson instead for these types. (optional)"`
-	CustomEventFilterJSON string `json:"customEventFilterJson,omitempty" jsonschema:"description:Omit to preserve; pass [] to clear. Custom event filter as JSON array for customEvent triggers. Condition types: equals\\, contains\\, doesNotContain\\, startsWith\\, endsWith\\, matchRegex. (optional)"`
-	ParameterJSON         string `json:"parameterJson,omitempty" jsonschema:"description:Omit to preserve; pass [] to clear. Trigger parameters as JSON array. For triggerGroup type use: [{key: triggerIds, type: list, list: [{type: triggerReference, value: triggerId}, ...]}]"`
+	FilterJSON            string `json:"filterJson,omitempty" jsonschema:"description:JSON conditions; omit to preserve\\, [] to clear; see gtm://best-practices/tool-input-formats"`
+	AutoEventFilterJSON   string `json:"autoEventFilterJson,omitempty" jsonschema:"description:JSON auto-event conditions; omit to preserve\\, [] to clear; see gtm://best-practices/tool-input-formats"`
+	CustomEventFilterJSON string `json:"customEventFilterJson,omitempty" jsonschema:"description:JSON custom-event conditions; omit to preserve\\, [] to clear; see gtm://best-practices/tool-input-formats"`
+	ParameterJSON         string `json:"parameterJson,omitempty" jsonschema:"description:JSON parameters; omit to preserve\\, [] to clear; see gtm://best-practices/tool-input-formats"`
 	Notes                 string `json:"notes,omitempty" jsonschema:"description:Trigger notes (optional)"`
 }
 
@@ -124,6 +124,6 @@ func registerUpdateTrigger(server *mcp.Server) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_trigger",
-		Description: "Update an existing trigger. Filter condition types: equals, contains, doesNotContain, startsWith, endsWith, matchRegex. The doesNotContain type is automatically transformed to a negated contains condition for the GTM API. For trigger groups, use parameterJson with format: [{\"key\": \"triggerIds\", \"type\": \"list\", \"list\": [{\"type\": \"triggerReference\", \"value\": \"<triggerId>\"}, ...]}]",
+		Description: "Update a trigger with automatic fingerprint handling. Read gtm://best-practices/tool-input-formats for filters and trigger groups.",
 	}, handler)
 }


### PR DESCRIPTION
The existing 51-tool surface serializes to 63,423 bytes before the remaining GTM API methods are added. This establishes a repeatable schema-size report, moves detailed mutation JSON examples into an MCP resource, and adds an 80 KB regression gate so parity work cannot silently consume unbounded client context.

After this change, the same 51 tools serialize to 59,569 bytes: 3,854 bytes smaller (about 964 tokens at the planning estimate of four bytes per token). Every input and output field remains present.

Changes:
- add `go run ./cmd/tool-schema-report` with total and per-tool size breakdowns
- add `gtm://best-practices/tool-input-formats` for tag, trigger, transformation, and template JSON shapes
- shorten the duplicated copies in the six largest mutation schemas
- fail tests above an 80 KB default `tools/list` result, which is the decision point for configurable tool groups

Validation:
- `go test ./... -count=1 -timeout=120s`
- `go vet ./...`
- `staticcheck ./...`
- `git diff --check`
