### PR TITLE
feat(gtm): add read-only container and version inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,8 @@ beside an already-running binary does not change that binary’s version.
 |------|-------------|
 | `list_accounts` | Gives all the GTM accounts |
 | `list_containers` | Gives the containers in an account |
+| `lookup_container` | Finds a container by a destination ID or GTM public tag ID |
+| `get_container_snippet` | Gives the install snippet or server container configuration |
 | `list_workspaces` | Gives the workspaces in a container |
 | `list_tags` | Gives all the tags in a workspace |
 | `get_tag` | Gives the data of one tag |
@@ -713,6 +715,8 @@ triggers, use `filterJson` because GTM ignores `autoEventFilter`.
 | `get_workspace_status` | Gives the changes and the merge conflicts before a version |
 | `list_versions` | Gives all the container versions with the counts of the items |
 | `get_latest_version_header` | Gets the latest container version header (which may differ from the live version) |
+| `get_version` | Gets a saved container version with all of its entities |
+| `get_live_version` | Gets the published live version with all of its entities |
 | `create_version` | Creates a version from the changes in a workspace |
 | `publish_version` | Publishes a version. Asks for approval |
 

--- a/gtm/containers.go
+++ b/gtm/containers.go
@@ -9,11 +9,18 @@ import (
 
 // Container is a simplified representation of a GTM container.
 type Container struct {
-	ContainerID  string   `json:"containerId"`
-	Name         string   `json:"name"`
-	PublicID     string   `json:"publicId"`
-	UsageContext []string `json:"usageContext"`
-	Path         string   `json:"path"`
+	ContainerID       string   `json:"containerId"`
+	Name              string   `json:"name"`
+	PublicID          string   `json:"publicId"`
+	UsageContext      []string `json:"usageContext"`
+	Path              string   `json:"path"`
+	DomainName        []string `json:"domainName,omitempty"`
+	TagIDs            []string `json:"tagIds,omitempty"`
+	TaggingServerURLs []string `json:"taggingServerUrls,omitempty"`
+	Notes             string   `json:"notes,omitempty"`
+	Fingerprint       string   `json:"fingerprint,omitempty"`
+	TagManagerURL     string   `json:"tagManagerUrl,omitempty"`
+	Features          any      `json:"features,omitempty"`
 }
 
 // ListContainers returns all containers in an account.
@@ -33,13 +40,27 @@ func (c *Client) ListContainers(ctx context.Context, accountID string) ([]Contai
 func toContainers(containers []*tagmanager.Container) []Container {
 	result := make([]Container, 0, len(containers))
 	for _, c := range containers {
-		result = append(result, Container{
-			ContainerID:  c.ContainerId,
-			Name:         c.Name,
-			PublicID:     c.PublicId,
-			UsageContext: c.UsageContext,
-			Path:         c.Path,
-		})
+		result = append(result, toContainer(c))
+	}
+	return result
+}
+
+func toContainer(c *tagmanager.Container) Container {
+	result := Container{
+		ContainerID:       c.ContainerId,
+		Name:              c.Name,
+		PublicID:          c.PublicId,
+		UsageContext:      c.UsageContext,
+		Path:              c.Path,
+		DomainName:        c.DomainName,
+		TagIDs:            c.TagIds,
+		TaggingServerURLs: c.TaggingServerUrls,
+		Notes:             c.Notes,
+		Fingerprint:       c.Fingerprint,
+		TagManagerURL:     c.TagManagerUrl,
+	}
+	if c.Features != nil {
+		result.Features = c.Features
 	}
 	return result
 }
@@ -63,13 +84,8 @@ func (c *Client) UpdateContainer(ctx context.Context, accountID, containerID, na
 		return nil, mapGoogleError(err)
 	}
 
-	return &Container{
-		ContainerID:  updated.ContainerId,
-		Name:         updated.Name,
-		PublicID:     updated.PublicId,
-		UsageContext: updated.UsageContext,
-		Path:         updated.Path,
-	}, nil
+	result := toContainer(updated)
+	return &result, nil
 }
 
 // DeleteContainer deletes a container by path.

--- a/gtm/inspection.go
+++ b/gtm/inspection.go
@@ -1,0 +1,152 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+// ContainerVersionDetails contains version metadata and the complete entity
+// collections returned by Google. Entity collections use their native JSON
+// representation without expanding those large recursive schemas in tools/list.
+type ContainerVersionDetails struct {
+	AccountID        string     `json:"accountId"`
+	ContainerID      string     `json:"containerId"`
+	VersionID        string     `json:"containerVersionId"`
+	Name             string     `json:"name,omitempty"`
+	Description      string     `json:"description,omitempty"`
+	Deleted          bool       `json:"deleted,omitempty"`
+	Fingerprint      string     `json:"fingerprint,omitempty"`
+	Path             string     `json:"path"`
+	TagManagerURL    string     `json:"tagManagerUrl,omitempty"`
+	Container        *Container `json:"container,omitempty"`
+	BuiltInVariables any        `json:"builtInVariable,omitempty"`
+	Clients          any        `json:"client,omitempty"`
+	CustomTemplates  any        `json:"customTemplate,omitempty"`
+	Folders          any        `json:"folder,omitempty"`
+	GoogleTagConfigs any        `json:"gtagConfig,omitempty"`
+	Tags             any        `json:"tag,omitempty"`
+	Transformations  any        `json:"transformation,omitempty"`
+	Triggers         any        `json:"trigger,omitempty"`
+	Variables        any        `json:"variable,omitempty"`
+	Zones            any        `json:"zone,omitempty"`
+}
+
+// ContainerSnippet contains the install snippet for web containers or the
+// provisioning configuration for server containers.
+type ContainerSnippet struct {
+	Snippet         string `json:"snippet,omitempty"`
+	ContainerConfig string `json:"containerConfig,omitempty"`
+}
+
+func (c *Client) GetContainerVersion(ctx context.Context, accountID, containerID, versionID string) (*ContainerVersionDetails, error) {
+	path := fmt.Sprintf("accounts/%s/containers/%s/versions/%s", accountID, containerID, versionID)
+	version, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ContainerVersion, error) {
+		return c.Service.Accounts.Containers.Versions.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toContainerVersionDetails(version)
+	return &result, nil
+}
+
+func (c *Client) GetLiveContainerVersion(ctx context.Context, accountID, containerID string) (*ContainerVersionDetails, error) {
+	parent := BuildContainerPath(accountID, containerID)
+	version, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ContainerVersion, error) {
+		return c.Service.Accounts.Containers.Versions.Live(parent).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toContainerVersionDetails(version)
+	return &result, nil
+}
+
+func (c *Client) LookupContainer(ctx context.Context, destinationID, tagID string) (*Container, error) {
+	destinationID = strings.TrimSpace(destinationID)
+	tagID = strings.TrimSpace(tagID)
+	if (destinationID == "") == (tagID == "") {
+		return nil, fmt.Errorf("provide exactly one of destination ID or tag ID")
+	}
+
+	call := c.Service.Accounts.Containers.Lookup()
+	if destinationID != "" {
+		call = call.DestinationId(destinationID)
+	} else {
+		call = call.TagId(tagID)
+	}
+	container, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Container, error) {
+		return call.Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toContainer(container)
+	return &result, nil
+}
+
+func (c *Client) GetContainerSnippet(ctx context.Context, accountID, containerID string) (*ContainerSnippet, error) {
+	path := BuildContainerPath(accountID, containerID)
+	response, err := retryWithBackoff(ctx, 3, func() (*tagmanager.GetContainerSnippetResponse, error) {
+		return c.Service.Accounts.Containers.Snippet(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	return &ContainerSnippet{
+		Snippet:         response.Snippet,
+		ContainerConfig: response.ContainerConfig,
+	}, nil
+}
+
+func toContainerVersionDetails(version *tagmanager.ContainerVersion) ContainerVersionDetails {
+	result := ContainerVersionDetails{
+		AccountID:     version.AccountId,
+		ContainerID:   version.ContainerId,
+		VersionID:     version.ContainerVersionId,
+		Name:          version.Name,
+		Description:   version.Description,
+		Deleted:       version.Deleted,
+		Fingerprint:   version.Fingerprint,
+		Path:          version.Path,
+		TagManagerURL: version.TagManagerUrl,
+	}
+	if version.Container != nil {
+		container := toContainer(version.Container)
+		result.Container = &container
+	}
+	if len(version.BuiltInVariable) > 0 {
+		result.BuiltInVariables = version.BuiltInVariable
+	}
+	if len(version.Client) > 0 {
+		result.Clients = version.Client
+	}
+	if len(version.CustomTemplate) > 0 {
+		result.CustomTemplates = version.CustomTemplate
+	}
+	if len(version.Folder) > 0 {
+		result.Folders = version.Folder
+	}
+	if len(version.GtagConfig) > 0 {
+		result.GoogleTagConfigs = version.GtagConfig
+	}
+	if len(version.Tag) > 0 {
+		result.Tags = version.Tag
+	}
+	if len(version.Transformation) > 0 {
+		result.Transformations = version.Transformation
+	}
+	if len(version.Trigger) > 0 {
+		result.Triggers = version.Trigger
+	}
+	if len(version.Variable) > 0 {
+		result.Variables = version.Variable
+	}
+	if len(version.Zone) > 0 {
+		result.Zones = version.Zone
+	}
+	return result
+}

--- a/gtm/inspection_test.go
+++ b/gtm/inspection_test.go
@@ -1,0 +1,156 @@
+package gtm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestGetContainerVersion(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/versions/7" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"accountId":"1","containerId":"2","containerVersionId":"7",
+			"name":"Release 7","description":"tested","fingerprint":"fp7",
+			"path":"accounts/1/containers/2/versions/7",
+			"container":{"containerId":"2","name":"Web","publicId":"GTM-ABC","tagIds":["G-123"],"domainName":["example.com"]},
+			"tag":[{"tagId":"10","name":"GA4","type":"googtag"}],
+			"trigger":[{"triggerId":"20","name":"All pages","type":"pageview"}]
+		}`)
+	})
+
+	got, err := client.GetContainerVersion(context.Background(), "1", "2", "7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.VersionID != "7" || got.Name != "Release 7" || got.Fingerprint != "fp7" {
+		t.Fatalf("unexpected version metadata: %+v", got)
+	}
+	if got.Container == nil || got.Container.PublicID != "GTM-ABC" || len(got.Container.TagIDs) != 1 {
+		t.Fatalf("unexpected container: %+v", got.Container)
+	}
+	if got.Tags == nil || got.Triggers == nil {
+		t.Fatalf("version entities were lost: tags=%v triggers=%v", got.Tags, got.Triggers)
+	}
+	if got.Variables != nil {
+		t.Fatalf("empty entity collection should be omitted: %v", got.Variables)
+	}
+}
+
+func TestGetLiveContainerVersion(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/versions:live" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"containerVersionId":"9","name":"Published","path":"accounts/1/containers/2/versions/9"}`)
+	})
+
+	got, err := client.GetLiveContainerVersion(context.Background(), "1", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.VersionID != "9" || got.Name != "Published" {
+		t.Fatalf("unexpected live version: %+v", got)
+	}
+}
+
+func TestLookupContainer(t *testing.T) {
+	tests := []struct {
+		name          string
+		destinationID string
+		tagID         string
+		wantQuery     url.Values
+	}{
+		{name: "destination ID", destinationID: "AW-123", wantQuery: url.Values{"destinationId": {"AW-123"}}},
+		{name: "tag ID", tagID: "GTM-ABC", wantQuery: url.Values{"tagId": {"GTM-ABC"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/containers:lookup" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+				}
+				query := r.URL.Query()
+				for key, values := range tt.wantQuery {
+					if query.Get(key) != values[0] {
+						t.Errorf("query %s=%q want %q", key, query.Get(key), values[0])
+					}
+				}
+				if query.Get("destinationId") != "" && query.Get("tagId") != "" {
+					t.Errorf("lookup sent both identifiers: %s", query.Encode())
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"containerId":"2","name":"Found","publicId":"GTM-ABC","tagIds":["AW-123"],"taggingServerUrls":["https://sgtm.example"]}`)
+			})
+
+			got, err := client.LookupContainer(context.Background(), tt.destinationID, tt.tagID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.ContainerID != "2" || len(got.TagIDs) != 1 || len(got.TaggingServerURLs) != 1 {
+				t.Fatalf("unexpected container: %+v", got)
+			}
+		})
+	}
+}
+
+func TestLookupContainerRequiresExactlyOneIdentifier(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("validation should prevent request: %s", r.URL)
+	})
+	for _, args := range [][2]string{{"", ""}, {"AW-123", "GTM-ABC"}, {" ", " "}} {
+		if _, err := client.LookupContainer(context.Background(), args[0], args[1]); err == nil {
+			t.Fatalf("LookupContainer(%q, %q) succeeded", args[0], args[1])
+		}
+	}
+}
+
+func TestGetContainerSnippet(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2:snippet" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"snippet":"<script>install</script>","containerConfig":"config-data"}`)
+	})
+
+	got, err := client.GetContainerSnippet(context.Background(), "1", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Snippet != "<script>install</script>" || got.ContainerConfig != "config-data" {
+		t.Fatalf("unexpected snippet: %+v", got)
+	}
+}
+
+func TestInspectionErrors(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"code":404,"message":"missing"}}`)
+	})
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{name: "get version", call: func() error { _, err := client.GetContainerVersion(context.Background(), "1", "2", "7"); return err }},
+		{name: "live version", call: func() error { _, err := client.GetLiveContainerVersion(context.Background(), "1", "2"); return err }},
+		{name: "lookup", call: func() error { _, err := client.LookupContainer(context.Background(), "", "GTM-ABC"); return err }},
+		{name: "snippet", call: func() error { _, err := client.GetContainerSnippet(context.Background(), "1", "2"); return err }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("error=%v, want ErrNotFound", err)
+			}
+		})
+	}
+}

--- a/gtm/tool_inspection.go
+++ b/gtm/tool_inspection.go
@@ -1,0 +1,109 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetVersionInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	VersionID   string `json:"versionId" jsonschema:"description:The saved container version ID"`
+}
+
+type GetVersionOutput struct {
+	Version ContainerVersionDetails `json:"version"`
+}
+
+type LookupContainerInput struct {
+	DestinationID string `json:"destinationId,omitempty" jsonschema:"description:A destination ID such as AW-123456; provide exactly one lookup field"`
+	TagID         string `json:"tagId,omitempty" jsonschema:"description:A GTM public ID such as GTM-ABC123; provide exactly one lookup field"`
+}
+
+type LookupContainerOutput struct {
+	Container Container `json:"container"`
+}
+
+type GetContainerSnippetOutput struct {
+	Snippet ContainerSnippet `json:"snippet"`
+}
+
+func registerGetVersion(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_version",
+		Description: "Get a saved container version with its tags, triggers, variables, templates, and other entities.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetVersionInput) (*mcp.CallToolResult, GetVersionOutput, error) {
+		cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+		if err != nil {
+			return nil, GetVersionOutput{}, err
+		}
+		versionID := strings.TrimSpace(input.VersionID)
+		if versionID == "" {
+			return nil, GetVersionOutput{}, fmt.Errorf("version ID is required")
+		}
+		version, err := cc.Client.GetContainerVersion(ctx, cc.AccountID, cc.ContainerID, versionID)
+		if err != nil {
+			return nil, GetVersionOutput{}, err
+		}
+		return nil, GetVersionOutput{Version: *version}, nil
+	})
+}
+
+func registerGetLiveVersion(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_live_version",
+		Description: "Get the published live container version with its complete entity collections.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListVersionsInput) (*mcp.CallToolResult, GetVersionOutput, error) {
+		cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+		if err != nil {
+			return nil, GetVersionOutput{}, err
+		}
+		version, err := cc.Client.GetLiveContainerVersion(ctx, cc.AccountID, cc.ContainerID)
+		if err != nil {
+			return nil, GetVersionOutput{}, err
+		}
+		return nil, GetVersionOutput{Version: *version}, nil
+	})
+}
+
+func registerLookupContainer(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "lookup_container",
+		Description: "Find a container by exactly one destination ID or GTM public tag ID.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input LookupContainerInput) (*mcp.CallToolResult, LookupContainerOutput, error) {
+		destinationID := strings.TrimSpace(input.DestinationID)
+		tagID := strings.TrimSpace(input.TagID)
+		if (destinationID == "") == (tagID == "") {
+			return nil, LookupContainerOutput{}, fmt.Errorf("provide exactly one of destinationId or tagId")
+		}
+		client, err := getClient(ctx)
+		if err != nil {
+			return nil, LookupContainerOutput{}, err
+		}
+		container, err := client.LookupContainer(ctx, destinationID, tagID)
+		if err != nil {
+			return nil, LookupContainerOutput{}, err
+		}
+		return nil, LookupContainerOutput{Container: *container}, nil
+	})
+}
+
+func registerGetContainerSnippet(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_container_snippet",
+		Description: "Get the install snippet for a web container or provisioning configuration for a server container.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListVersionsInput) (*mcp.CallToolResult, GetContainerSnippetOutput, error) {
+		cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+		if err != nil {
+			return nil, GetContainerSnippetOutput{}, err
+		}
+		snippet, err := cc.Client.GetContainerSnippet(ctx, cc.AccountID, cc.ContainerID)
+		if err != nil {
+			return nil, GetContainerSnippetOutput{}, err
+		}
+		return nil, GetContainerSnippetOutput{Snippet: *snippet}, nil
+	})
+}

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -15,6 +15,8 @@ func RegisterTools(server *mcp.Server) {
 	registerListAccounts(server)
 	registerUpdateAccount(server)
 	registerListContainers(server)
+	registerLookupContainer(server)
+	registerGetContainerSnippet(server)
 	registerListWorkspaces(server)
 	registerListTags(server)
 	registerGetTag(server)
@@ -28,6 +30,8 @@ func RegisterTools(server *mcp.Server) {
 	registerGetTemplate(server)
 	registerListVersions(server)
 	registerGetLatestVersionHeader(server)
+	registerGetVersion(server)
+	registerGetLiveVersion(server)
 
 	// Write operations
 	registerCreateTag(server)

--- a/llms.txt
+++ b/llms.txt
@@ -35,6 +35,8 @@ Always discover IDs by listing — never guess or hardcode them.
 |------|---------|
 | `list_accounts` | List all GTM accounts the user has access to |
 | `list_containers` | List containers in an account (needs accountId) |
+| `lookup_container` | Find a container by destinationId or public tagId |
+| `get_container_snippet` | Get the web snippet or server container configuration |
 | `list_workspaces` | List workspaces in a container (needs accountId, containerId) |
 | `list_tags` | List all tags in a workspace |
 | `get_tag` | Get full tag details by ID |
@@ -89,6 +91,8 @@ Always discover IDs by listing — never guess or hardcode them.
 | `publish_version` | Publish a version to go live (requires `confirm: true`) |
 | `list_versions` | List all container version headers, across all pages |
 | `get_latest_version_header` | Get the latest version header; latest is not necessarily live |
+| `get_version` | Get a saved version with all entity collections |
+| `get_live_version` | Get the published live version with all entity collections |
 
 ### Templates
 | Tool | Purpose |


### PR DESCRIPTION
Adds the first read-only API-parity slice so clients can resolve containers and inspect saved or published container state. It exposes `containers.lookup`, `containers.snippet`, `versions.get`, and `versions.live` as four focused MCP tools, while preserving complete version entity collections without expanding recursive Google types into every `tools/list` response.

This PR is stacked on #111 because it relies on the schema-budget guard and report added there. After #111 merges, its base can be changed to `main`.

Validation:
- `go test ./... -count=1 -timeout=120s`
- `go vet ./...`
- `staticcheck ./...`
- schema report: 55 tools, 65,549 bytes (14,451 bytes below the 80 KB budget)
