### PR TITLE
feat(gtm): add workspace metadata and preview tools

### DIFF
--- a/gtm/tool_workspace_metadata.go
+++ b/gtm/tool_workspace_metadata.go
@@ -1,0 +1,129 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type WorkspaceInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+}
+
+type WorkspaceOutput struct {
+	Workspace Workspace `json:"workspace"`
+}
+
+type UpdateWorkspaceInput struct {
+	AccountID   string  `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string  `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID string  `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	Name        *string `json:"name,omitempty" jsonschema:"description:New workspace name; omit to preserve it"`
+	Description *string `json:"description,omitempty" jsonschema:"description:New description; omit to preserve or pass an empty string to clear"`
+}
+
+type UpdateWorkspaceOutput struct {
+	Success   bool      `json:"success"`
+	Workspace Workspace `json:"workspace"`
+	Message   string    `json:"message"`
+}
+
+type DeleteWorkspaceInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to confirm workspace deletion"`
+}
+
+type DeleteWorkspaceOutput struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+type QuickPreviewWorkspaceOutput struct {
+	Preview WorkspacePreview `json:"preview"`
+}
+
+func registerGetWorkspace(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_workspace",
+		Description: "Get workspace metadata including its current fingerprint.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input WorkspaceInput) (*mcp.CallToolResult, WorkspaceOutput, error) {
+		wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+		if err != nil {
+			return nil, WorkspaceOutput{}, err
+		}
+		workspace, err := wc.Client.GetWorkspace(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID)
+		if err != nil {
+			return nil, WorkspaceOutput{}, err
+		}
+		return nil, WorkspaceOutput{Workspace: *workspace}, nil
+	})
+}
+
+func registerUpdateWorkspace(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_workspace",
+		Description: "Update a workspace name or description while preserving omitted fields and checking its fingerprint.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateWorkspaceInput) (*mcp.CallToolResult, UpdateWorkspaceOutput, error) {
+		wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+		if err != nil {
+			return nil, UpdateWorkspaceOutput{}, err
+		}
+		if input.Name == nil && input.Description == nil {
+			return nil, UpdateWorkspaceOutput{}, fmt.Errorf("provide at least one of name or description")
+		}
+		if input.Name != nil && strings.TrimSpace(*input.Name) == "" {
+			return nil, UpdateWorkspaceOutput{}, fmt.Errorf("name cannot be empty")
+		}
+		workspace, err := wc.Client.UpdateWorkspace(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.Name, input.Description)
+		if err != nil {
+			return nil, UpdateWorkspaceOutput{}, err
+		}
+		return nil, UpdateWorkspaceOutput{
+			Success:   true,
+			Workspace: *workspace,
+			Message:   "Workspace updated successfully",
+		}, nil
+	})
+}
+
+func registerDeleteWorkspace(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_workspace",
+		Description: "Delete a workspace and its pending changes. Requires confirm: true.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteWorkspaceInput) (*mcp.CallToolResult, DeleteWorkspaceOutput, error) {
+		if !input.Confirm {
+			return nil, DeleteWorkspaceOutput{Message: "Workspace deletion requires confirm: true"}, nil
+		}
+		wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+		if err != nil {
+			return nil, DeleteWorkspaceOutput{}, err
+		}
+		if err := wc.Client.DeleteWorkspace(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID); err != nil {
+			return nil, DeleteWorkspaceOutput{}, err
+		}
+		return nil, DeleteWorkspaceOutput{Success: true, Message: "Workspace deleted successfully"}, nil
+	})
+}
+
+func registerQuickPreviewWorkspace(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "quick_preview_workspace",
+		Description: "Compile an ephemeral preview version of a workspace without saving or publishing it.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input WorkspaceInput) (*mcp.CallToolResult, QuickPreviewWorkspaceOutput, error) {
+		wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+		if err != nil {
+			return nil, QuickPreviewWorkspaceOutput{}, err
+		}
+		preview, err := wc.Client.QuickPreviewWorkspace(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID)
+		if err != nil {
+			return nil, QuickPreviewWorkspaceOutput{}, err
+		}
+		return nil, QuickPreviewWorkspaceOutput{Preview: *preview}, nil
+	})
+}

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -18,6 +18,8 @@ func RegisterTools(server *mcp.Server) {
 	registerLookupContainer(server)
 	registerGetContainerSnippet(server)
 	registerListWorkspaces(server)
+	registerGetWorkspace(server)
+	registerQuickPreviewWorkspace(server)
 	registerListTags(server)
 	registerGetTag(server)
 	registerListTriggers(server)
@@ -47,6 +49,8 @@ func RegisterTools(server *mcp.Server) {
 	registerUpdateContainer(server)
 	registerDeleteContainer(server)
 	registerCreateWorkspace(server)
+	registerUpdateWorkspace(server)
+	registerDeleteWorkspace(server)
 
 	// Workspace status
 	registerGetWorkspaceStatus(server)

--- a/gtm/workspace_metadata.go
+++ b/gtm/workspace_metadata.go
@@ -1,0 +1,94 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+// WorkspacePreview is the ephemeral version produced by Google's quick
+// preview endpoint together with synchronization and compiler status.
+type WorkspacePreview struct {
+	CompilerError bool                     `json:"compilerError"`
+	SyncStatus    *WorkspacePreviewStatus  `json:"syncStatus,omitempty"`
+	Version       *ContainerVersionDetails `json:"containerVersion,omitempty"`
+}
+
+type WorkspacePreviewStatus struct {
+	MergeConflict bool `json:"mergeConflict"`
+	SyncError     bool `json:"syncError"`
+}
+
+func (c *Client) GetWorkspace(ctx context.Context, accountID, containerID, workspaceID string) (*Workspace, error) {
+	path := BuildWorkspacePath(accountID, containerID, workspaceID)
+	workspace, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Workspace, error) {
+		return c.Service.Accounts.Containers.Workspaces.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toWorkspace(workspace)
+	return &result, nil
+}
+
+func (c *Client) UpdateWorkspace(ctx context.Context, accountID, containerID, workspaceID string, name, description *string) (*Workspace, error) {
+	if name == nil && description == nil {
+		return nil, fmt.Errorf("provide at least one of name or description")
+	}
+	path := BuildWorkspacePath(accountID, containerID, workspaceID)
+	current, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Workspace, error) {
+		return c.Service.Accounts.Containers.Workspaces.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+
+	update := &tagmanager.Workspace{Name: current.Name, Description: current.Description}
+	if name != nil {
+		update.Name = *name
+	}
+	if description != nil {
+		update.Description = *description
+		if *description == "" {
+			update.ForceSendFields = append(update.ForceSendFields, "Description")
+		}
+	}
+	updated, err := c.Service.Accounts.Containers.Workspaces.Update(path, update).
+		Fingerprint(current.Fingerprint).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toWorkspace(updated)
+	return &result, nil
+}
+
+func (c *Client) DeleteWorkspace(ctx context.Context, accountID, containerID, workspaceID string) error {
+	path := BuildWorkspacePath(accountID, containerID, workspaceID)
+	err := c.Service.Accounts.Containers.Workspaces.Delete(path).Context(ctx).Do()
+	return mapGoogleError(err)
+}
+
+func (c *Client) QuickPreviewWorkspace(ctx context.Context, accountID, containerID, workspaceID string) (*WorkspacePreview, error) {
+	path := BuildWorkspacePath(accountID, containerID, workspaceID)
+	preview, err := retryWithBackoff(ctx, 3, func() (*tagmanager.QuickPreviewResponse, error) {
+		return c.Service.Accounts.Containers.Workspaces.QuickPreview(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := &WorkspacePreview{CompilerError: preview.CompilerError}
+	if preview.SyncStatus != nil {
+		result.SyncStatus = &WorkspacePreviewStatus{
+			MergeConflict: preview.SyncStatus.MergeConflict,
+			SyncError:     preview.SyncStatus.SyncError,
+		}
+	}
+	if preview.ContainerVersion != nil {
+		version := toContainerVersionDetails(preview.ContainerVersion)
+		result.Version = &version
+	}
+	return result, nil
+}

--- a/gtm/workspace_metadata_test.go
+++ b/gtm/workspace_metadata_test.go
@@ -1,0 +1,219 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestListWorkspacesPaginationAndFields(t *testing.T) {
+	calls := 0
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			fmt.Fprint(w, `{"workspace":[{"accountId":"1","containerId":"2","workspaceId":"3","name":"First","fingerprint":"fp3","tagManagerUrl":"https://tagmanager.example/3"}],"nextPageToken":"next"}`)
+		case "next":
+			fmt.Fprint(w, `{"workspace":[{"workspaceId":"4","name":"Second"}]}`)
+		default:
+			t.Errorf("unexpected page token: %q", r.URL.Query().Get("pageToken"))
+		}
+	})
+
+	got, err := client.ListWorkspaces(context.Background(), "1", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || len(got) != 2 {
+		t.Fatalf("calls=%d workspaces=%+v", calls, got)
+	}
+	if got[0].AccountID != "1" || got[0].Fingerprint != "fp3" || got[0].TagManagerURL == "" {
+		t.Fatalf("workspace fields were lost: %+v", got[0])
+	}
+}
+
+func TestGetWorkspace(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"accountId":"1","containerId":"2","workspaceId":"3","name":"Main","description":"Current","fingerprint":"fp3","path":"accounts/1/containers/2/workspaces/3"}`)
+	})
+
+	got, err := client.GetWorkspace(context.Background(), "1", "2", "3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.WorkspaceID != "3" || got.Description != "Current" || got.Fingerprint != "fp3" {
+		t.Fatalf("unexpected workspace: %+v", got)
+	}
+}
+
+func TestUpdateWorkspacePreservesNameAndClearsDescription(t *testing.T) {
+	calls := 0
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if r.Method != http.MethodGet {
+				t.Errorf("first method=%s", r.Method)
+			}
+			fmt.Fprint(w, `{"workspaceId":"3","name":"Keep me","description":"Clear me","fingerprint":"current-fp"}`)
+		case 2:
+			if r.Method != http.MethodPut {
+				t.Errorf("second method=%s", r.Method)
+			}
+			if got := r.URL.Query().Get("fingerprint"); got != "current-fp" {
+				t.Errorf("fingerprint=%q", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body["name"] != "Keep me" {
+				t.Errorf("name not preserved: %v", body)
+			}
+			if value, present := body["description"]; !present || value != "" {
+				t.Errorf("description not explicitly cleared: %v", body)
+			}
+			fmt.Fprint(w, `{"workspaceId":"3","name":"Keep me","fingerprint":"new-fp"}`)
+		default:
+			t.Fatalf("unexpected call %d", calls)
+		}
+	})
+
+	empty := ""
+	got, err := client.UpdateWorkspace(context.Background(), "1", "2", "3", nil, &empty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || got.Name != "Keep me" || got.Description != "" || got.Fingerprint != "new-fp" {
+		t.Fatalf("calls=%d workspace=%+v", calls, got)
+	}
+}
+
+func TestUpdateWorkspaceRequiresAChange(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("validation should prevent request: %s", r.URL)
+	})
+	if _, err := client.UpdateWorkspace(context.Background(), "1", "2", "3", nil, nil); err == nil {
+		t.Fatal("UpdateWorkspace succeeded without a change")
+	}
+}
+
+func TestDeleteWorkspace(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	if err := client.DeleteWorkspace(context.Background(), "1", "2", "3"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestQuickPreviewWorkspace(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3:quick_preview" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"compilerError":true,"syncStatus":{"mergeConflict":true,"syncError":false},"containerVersion":{"name":"Quick Preview","tag":[{"tagId":"10","name":"Preview tag"}]}}`)
+	})
+
+	got, err := client.QuickPreviewWorkspace(context.Background(), "1", "2", "3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.CompilerError || got.SyncStatus == nil || !got.SyncStatus.MergeConflict {
+		t.Fatalf("unexpected preview status: %+v", got)
+	}
+	if got.Version == nil || got.Version.Name != "Quick Preview" || got.Version.Tags == nil {
+		t.Fatalf("preview version was lost: %+v", got.Version)
+	}
+}
+
+func TestWorkspaceMetadataErrors(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"code":404,"message":"missing workspace"}}`)
+	})
+	name := "New"
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{name: "get", call: func() error { _, err := client.GetWorkspace(context.Background(), "1", "2", "3"); return err }},
+		{name: "update", call: func() error {
+			_, err := client.UpdateWorkspace(context.Background(), "1", "2", "3", &name, nil)
+			return err
+		}},
+		{name: "delete", call: func() error { return client.DeleteWorkspace(context.Background(), "1", "2", "3") }},
+		{name: "preview", call: func() error { _, err := client.QuickPreviewWorkspace(context.Background(), "1", "2", "3"); return err }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("error=%v, want ErrNotFound", err)
+			}
+		})
+	}
+}
+
+func TestDeleteWorkspaceRequiresConfirmationBeforeAuth(t *testing.T) {
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	registerDeleteWorkspace(server)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name: "delete_workspace",
+		Arguments: map[string]any{
+			"accountId": "1", "containerId": "2", "workspaceId": "3", "confirm": false,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("confirmation guard returned protocol error: %+v", result)
+	}
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output DeleteWorkspaceOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Success || output.Message == "" {
+		t.Fatalf("unexpected output: %+v", output)
+	}
+}

--- a/gtm/workspaces.go
+++ b/gtm/workspaces.go
@@ -9,35 +9,54 @@ import (
 
 // Workspace is a simplified representation of a GTM workspace.
 type Workspace struct {
-	WorkspaceID string `json:"workspaceId"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Path        string `json:"path"`
+	AccountID     string `json:"accountId,omitempty"`
+	ContainerID   string `json:"containerId,omitempty"`
+	WorkspaceID   string `json:"workspaceId"`
+	Name          string `json:"name"`
+	Description   string `json:"description,omitempty"`
+	Fingerprint   string `json:"fingerprint,omitempty"`
+	Path          string `json:"path"`
+	TagManagerURL string `json:"tagManagerUrl,omitempty"`
 }
 
 // ListWorkspaces returns all workspaces in a container.
 func (c *Client) ListWorkspaces(ctx context.Context, accountID, containerID string) ([]Workspace, error) {
 	parent := fmt.Sprintf("accounts/%s/containers/%s", accountID, containerID)
 
-	resp, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListWorkspacesResponse, error) {
-		return c.Service.Accounts.Containers.Workspaces.List(parent).Context(ctx).Do()
-	})
-	if err != nil {
-		return nil, mapGoogleError(err)
+	result := make([]Workspace, 0)
+	pageToken := ""
+	for {
+		resp, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListWorkspacesResponse, error) {
+			return c.Service.Accounts.Containers.Workspaces.List(parent).PageToken(pageToken).Context(ctx).Do()
+		})
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result = append(result, toWorkspaces(resp.Workspace)...)
+		pageToken = resp.NextPageToken
+		if pageToken == "" {
+			return result, nil
+		}
 	}
-
-	return toWorkspaces(resp.Workspace), nil
 }
 
 func toWorkspaces(workspaces []*tagmanager.Workspace) []Workspace {
 	result := make([]Workspace, 0, len(workspaces))
 	for _, w := range workspaces {
-		result = append(result, Workspace{
-			WorkspaceID: w.WorkspaceId,
-			Name:        w.Name,
-			Description: w.Description,
-			Path:        w.Path,
-		})
+		result = append(result, toWorkspace(w))
 	}
 	return result
+}
+
+func toWorkspace(workspace *tagmanager.Workspace) Workspace {
+	return Workspace{
+		AccountID:     workspace.AccountId,
+		ContainerID:   workspace.ContainerId,
+		WorkspaceID:   workspace.WorkspaceId,
+		Name:          workspace.Name,
+		Description:   workspace.Description,
+		Fingerprint:   workspace.Fingerprint,
+		Path:          workspace.Path,
+		TagManagerURL: workspace.TagManagerUrl,
+	}
 }

--- a/llms.txt
+++ b/llms.txt
@@ -38,6 +38,8 @@ Always discover IDs by listing — never guess or hardcode them.
 | `lookup_container` | Find a container by destinationId or public tagId |
 | `get_container_snippet` | Get the web snippet or server container configuration |
 | `list_workspaces` | List workspaces in a container (needs accountId, containerId) |
+| `get_workspace` | Get workspace metadata and its fingerprint |
+| `quick_preview_workspace` | Compile an ephemeral preview without saving or publishing it |
 | `list_tags` | List all tags in a workspace |
 | `get_tag` | Get full tag details by ID |
 | `list_triggers` | List all triggers in a workspace |
@@ -65,6 +67,8 @@ Always discover IDs by listing — never guess or hardcode them.
 | `update_container` | Rename a container |
 | `delete_container` | Remove a container (requires `confirm: true`) |
 | `create_workspace` | Create a new workspace |
+| `update_workspace` | Update a workspace name or description |
+| `delete_workspace` | Delete a workspace and pending changes (requires `confirm: true`) |
 | `update_account` | Rename a GTM account |
 | `enable_built_in_variables` | Enable built-in variable types |
 | `disable_built_in_variables` | Disable built-in variable types (requires `confirm: true`) |


### PR DESCRIPTION
Adds the second API-parity slice for workspace metadata and ephemeral preview. MCP clients can now get workspace metadata, update name or description, delete a workspace with explicit confirmation, and compile a quick preview without saving or publishing a version.

Updates preserve omitted fields, allow an explicitly empty description to clear it, and use the current workspace fingerprint for optimistic concurrency. The existing `list_workspaces` operation now follows every pagination token and returns fingerprint, account/container IDs, and the GTM UI URL.

Validation:
- request-level tests assert get/update/delete/quick-preview paths and methods
- update tests assert fingerprint query, omitted-name preservation, and explicit description clearing
- delete confirmation is tested before authentication
- list pagination and later-page aggregation are covered
- Google 404 responses map to `ErrNotFound`
- `go test ./... -count=1 -timeout=120s`
- `go vet ./...`
- `staticcheck ./...`
- schema report: 59 GTM tools, 70,814 bytes (9,186 bytes below budget)

The comprehensive README rewrite remains isolated in #113. Its coverage and tool tables should be advanced after this code PR merges.
