### PR TITLE
feat(gtm): add zone CRUD tools

### DIFF
--- a/gtm/tool_zones.go
+++ b/gtm/tool_zones.go
@@ -1,0 +1,205 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ZoneInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	ZoneID      string `json:"zoneId" jsonschema:"description:The GTM zone ID"`
+}
+
+type ListZonesOutput struct {
+	Zones []Zone `json:"zones"`
+}
+
+type ZoneOutput struct {
+	Zone Zone `json:"zone"`
+}
+
+type ZoneMutationOutput struct {
+	Success bool   `json:"success"`
+	Zone    Zone   `json:"zone"`
+	Message string `json:"message"`
+}
+
+type CreateZoneInput struct {
+	AccountID                  string                    `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID                string                    `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID                string                    `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	Name                       string                    `json:"name" jsonschema:"description:Zone display name"`
+	Notes                      string                    `json:"notes,omitempty" jsonschema:"description:Optional zone notes"`
+	BoundaryConditionsJSON     string                    `json:"boundaryConditionsJson,omitempty" jsonschema:"description:JSON array of boundary conditions; see the trigger condition format"`
+	CustomEvaluationTriggerIDs []string                  `json:"customEvaluationTriggerIds,omitempty" jsonschema:"description:Trigger IDs that cause boundary evaluation"`
+	ChildContainers            []ZoneChildContainerInput `json:"childContainers,omitempty" jsonschema:"description:Containers governed as children of this zone"`
+	TypeRestriction            *ZoneTypeRestrictionInput `json:"typeRestriction,omitempty" jsonschema:"description:Optional tag type restriction settings"`
+}
+
+type UpdateZoneInput struct {
+	AccountID                  string                     `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID                string                     `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID                string                     `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	ZoneID                     string                     `json:"zoneId" jsonschema:"description:The GTM zone ID"`
+	Name                       *string                    `json:"name,omitempty" jsonschema:"description:New name; omit to preserve"`
+	Notes                      *string                    `json:"notes,omitempty" jsonschema:"description:New notes; omit to preserve or pass empty to clear"`
+	BoundaryConditionsJSON     *string                    `json:"boundaryConditionsJson,omitempty" jsonschema:"description:JSON boundary conditions; omit to preserve or pass [] to clear"`
+	CustomEvaluationTriggerIDs *[]string                  `json:"customEvaluationTriggerIds,omitempty" jsonschema:"description:Trigger IDs; omit to preserve or pass [] to clear"`
+	ChildContainers            *[]ZoneChildContainerInput `json:"childContainers,omitempty" jsonschema:"description:Child containers; omit to preserve or pass [] to clear"`
+	TypeRestriction            *ZoneTypeRestrictionInput  `json:"typeRestriction,omitempty" jsonschema:"description:New tag type restriction settings; omit to preserve"`
+}
+
+type DeleteZoneInput struct {
+	ZoneInput
+	Confirm bool `json:"confirm" jsonschema:"description:Must be true to confirm zone deletion"`
+}
+
+type DeleteZoneOutput struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+func registerListZones(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "list_zones", Description: "List zones in a GTM workspace."},
+		func(ctx context.Context, req *mcp.CallToolRequest, input WorkspaceInput) (*mcp.CallToolResult, ListZonesOutput, error) {
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, ListZonesOutput{}, err
+			}
+			zones, err := wc.Client.ListZones(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID)
+			return nil, ListZonesOutput{Zones: zones}, err
+		})
+}
+
+func registerGetZone(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "get_zone", Description: "Get a zone and its boundary, child containers, and type restrictions."},
+		func(ctx context.Context, req *mcp.CallToolRequest, input ZoneInput) (*mcp.CallToolResult, ZoneOutput, error) {
+			wc, err := resolveZone(ctx, input)
+			if err != nil {
+				return nil, ZoneOutput{}, err
+			}
+			zone, err := wc.Client.GetZone(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.ZoneID)
+			if err != nil {
+				return nil, ZoneOutput{}, err
+			}
+			return nil, ZoneOutput{Zone: *zone}, nil
+		})
+}
+
+func registerCreateZone(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "create_zone", Description: "Create a zone in a GTM workspace."},
+		func(ctx context.Context, req *mcp.CallToolRequest, input CreateZoneInput) (*mcp.CallToolResult, ZoneMutationOutput, error) {
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, ZoneMutationOutput{}, err
+			}
+			if strings.TrimSpace(input.Name) == "" {
+				return nil, ZoneMutationOutput{}, fmt.Errorf("name is required")
+			}
+			conditions, err := parseZoneConditions(input.BoundaryConditionsJSON)
+			if err != nil {
+				return nil, ZoneMutationOutput{}, err
+			}
+			if err := validateZoneChildren(input.ChildContainers); err != nil {
+				return nil, ZoneMutationOutput{}, err
+			}
+			zone, err := wc.Client.CreateZone(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, ZoneCreateConfig{
+				Name: input.Name, Notes: input.Notes, BoundaryConditions: conditions,
+				CustomEvaluationTriggerIDs: input.CustomEvaluationTriggerIDs,
+				ChildContainers:            input.ChildContainers, TypeRestriction: input.TypeRestriction,
+			})
+			if err != nil {
+				return nil, ZoneMutationOutput{}, err
+			}
+			return nil, ZoneMutationOutput{Success: true, Zone: *zone, Message: "Zone created successfully"}, nil
+		})
+}
+
+func registerUpdateZone(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "update_zone", Description: "Update selected zone fields while preserving omitted values and checking its fingerprint."},
+		func(ctx context.Context, req *mcp.CallToolRequest, input UpdateZoneInput) (*mcp.CallToolResult, ZoneMutationOutput, error) {
+			wc, err := resolveZone(ctx, ZoneInput{input.AccountID, input.ContainerID, input.WorkspaceID, input.ZoneID})
+			if err != nil {
+				return nil, ZoneMutationOutput{}, err
+			}
+			if input.Name == nil && input.Notes == nil && input.BoundaryConditionsJSON == nil &&
+				input.CustomEvaluationTriggerIDs == nil && input.ChildContainers == nil && input.TypeRestriction == nil {
+				return nil, ZoneMutationOutput{}, fmt.Errorf("provide at least one field to update")
+			}
+			if input.Name != nil && strings.TrimSpace(*input.Name) == "" {
+				return nil, ZoneMutationOutput{}, fmt.Errorf("name cannot be empty")
+			}
+			var conditions *[]Condition
+			if input.BoundaryConditionsJSON != nil {
+				parsed, err := parseZoneConditions(*input.BoundaryConditionsJSON)
+				if err != nil {
+					return nil, ZoneMutationOutput{}, err
+				}
+				conditions = &parsed
+			}
+			if input.ChildContainers != nil {
+				if err := validateZoneChildren(*input.ChildContainers); err != nil {
+					return nil, ZoneMutationOutput{}, err
+				}
+			}
+			zone, err := wc.Client.UpdateZone(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.ZoneID, ZoneUpdateConfig{
+				Name: input.Name, Notes: input.Notes, BoundaryConditions: conditions,
+				CustomEvaluationTriggerIDs: input.CustomEvaluationTriggerIDs,
+				ChildContainers:            input.ChildContainers, TypeRestriction: input.TypeRestriction,
+			})
+			if err != nil {
+				return nil, ZoneMutationOutput{}, err
+			}
+			return nil, ZoneMutationOutput{Success: true, Zone: *zone, Message: "Zone updated successfully"}, nil
+		})
+}
+
+func registerDeleteZone(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "delete_zone", Description: "Delete a zone and require confirm: true."},
+		func(ctx context.Context, req *mcp.CallToolRequest, input DeleteZoneInput) (*mcp.CallToolResult, DeleteZoneOutput, error) {
+			if !input.Confirm {
+				return nil, DeleteZoneOutput{Message: "Zone deletion requires confirm: true"}, nil
+			}
+			wc, err := resolveZone(ctx, input.ZoneInput)
+			if err != nil {
+				return nil, DeleteZoneOutput{}, err
+			}
+			if err := wc.Client.DeleteZone(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.ZoneID); err != nil {
+				return nil, DeleteZoneOutput{}, err
+			}
+			return nil, DeleteZoneOutput{Success: true, Message: "Zone deleted successfully"}, nil
+		})
+}
+
+func resolveZone(ctx context.Context, input ZoneInput) (*WorkspaceContext, error) {
+	if strings.TrimSpace(input.ZoneID) == "" {
+		return nil, fmt.Errorf("zone ID is required")
+	}
+	return resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+}
+
+func parseZoneConditions(raw string) ([]Condition, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var conditions []Condition
+	if err := json.Unmarshal([]byte(raw), &conditions); err != nil {
+		return nil, fmt.Errorf("invalid boundaryConditionsJson: %w", err)
+	}
+	return conditions, nil
+}
+
+func validateZoneChildren(children []ZoneChildContainerInput) error {
+	for _, child := range children {
+		if strings.TrimSpace(child.PublicID) == "" {
+			return fmt.Errorf("child container publicId cannot be empty")
+		}
+	}
+	return nil
+}

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -34,6 +34,8 @@ func RegisterTools(server *mcp.Server) {
 	registerGetLatestVersionHeader(server)
 	registerGetVersion(server)
 	registerGetLiveVersion(server)
+	registerListZones(server)
+	registerGetZone(server)
 
 	// Write operations
 	registerCreateTag(server)
@@ -51,6 +53,9 @@ func RegisterTools(server *mcp.Server) {
 	registerCreateWorkspace(server)
 	registerUpdateWorkspace(server)
 	registerDeleteWorkspace(server)
+	registerCreateZone(server)
+	registerUpdateZone(server)
+	registerDeleteZone(server)
 
 	// Workspace status
 	registerGetWorkspaceStatus(server)

--- a/gtm/zones.go
+++ b/gtm/zones.go
@@ -1,0 +1,225 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+// Zone is a compact representation of a GTM zone. The three configuration
+// objects retain Google's JSON shape without expanding the MCP output schema.
+type Zone struct {
+	AccountID       string `json:"accountId"`
+	ContainerID     string `json:"containerId"`
+	WorkspaceID     string `json:"workspaceId"`
+	ZoneID          string `json:"zoneId"`
+	Name            string `json:"name"`
+	Notes           string `json:"notes,omitempty"`
+	Fingerprint     string `json:"fingerprint"`
+	Path            string `json:"path"`
+	TagManagerURL   string `json:"tagManagerUrl,omitempty"`
+	Boundary        any    `json:"boundary,omitempty"`
+	ChildContainers any    `json:"childContainer,omitempty"`
+	TypeRestriction any    `json:"typeRestriction,omitempty"`
+}
+
+type ZoneChildContainerInput struct {
+	PublicID string `json:"publicId" jsonschema:"description:Child container public ID such as GTM-ABC123"`
+	Nickname string `json:"nickname,omitempty" jsonschema:"description:Optional nickname inside the zone"`
+}
+
+type ZoneTypeRestrictionInput struct {
+	Enabled            bool     `json:"enabled" jsonschema:"description:Whether tag type restrictions are enabled"`
+	WhitelistedTypeIDs []string `json:"whitelistedTypeIds,omitempty" jsonschema:"description:Allowed tag template public IDs"`
+}
+
+type ZoneCreateConfig struct {
+	Name                       string                    `json:"name"`
+	Notes                      string                    `json:"notes,omitempty"`
+	BoundaryConditions         []Condition               `json:"-"`
+	CustomEvaluationTriggerIDs []string                  `json:"-"`
+	ChildContainers            []ZoneChildContainerInput `json:"-"`
+	TypeRestriction            *ZoneTypeRestrictionInput `json:"-"`
+}
+
+type ZoneUpdateConfig struct {
+	Name                       *string
+	Notes                      *string
+	BoundaryConditions         *[]Condition
+	CustomEvaluationTriggerIDs *[]string
+	ChildContainers            *[]ZoneChildContainerInput
+	TypeRestriction            *ZoneTypeRestrictionInput
+}
+
+func (c *Client) ListZones(ctx context.Context, accountID, containerID, workspaceID string) ([]Zone, error) {
+	parent := BuildWorkspacePath(accountID, containerID, workspaceID)
+	zones := make([]Zone, 0)
+	pageToken := ""
+	for {
+		response, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListZonesResponse, error) {
+			return c.Service.Accounts.Containers.Workspaces.Zones.List(parent).PageToken(pageToken).Context(ctx).Do()
+		})
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		for _, zone := range response.Zone {
+			zones = append(zones, toZone(zone))
+		}
+		if response.NextPageToken == "" {
+			return zones, nil
+		}
+		pageToken = response.NextPageToken
+	}
+}
+
+func (c *Client) GetZone(ctx context.Context, accountID, containerID, workspaceID, zoneID string) (*Zone, error) {
+	path := BuildZonePath(accountID, containerID, workspaceID, zoneID)
+	zone, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Zone, error) {
+		return c.Service.Accounts.Containers.Workspaces.Zones.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toZone(zone)
+	return &result, nil
+}
+
+func (c *Client) CreateZone(ctx context.Context, accountID, containerID, workspaceID string, config ZoneCreateConfig) (*Zone, error) {
+	created, err := c.Service.Accounts.Containers.Workspaces.Zones.Create(
+		BuildWorkspacePath(accountID, containerID, workspaceID), zoneFromCreateConfig(config),
+	).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toZone(created)
+	return &result, nil
+}
+
+func (c *Client) UpdateZone(ctx context.Context, accountID, containerID, workspaceID, zoneID string, config ZoneUpdateConfig) (*Zone, error) {
+	path := BuildZonePath(accountID, containerID, workspaceID, zoneID)
+	current, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Zone, error) {
+		return c.Service.Accounts.Containers.Workspaces.Zones.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	update := &tagmanager.Zone{
+		Name:            current.Name,
+		Notes:           current.Notes,
+		Boundary:        current.Boundary,
+		ChildContainer:  current.ChildContainer,
+		TypeRestriction: current.TypeRestriction,
+	}
+	applyZoneUpdate(update, config)
+	updated, err := c.Service.Accounts.Containers.Workspaces.Zones.Update(path, update).
+		Fingerprint(current.Fingerprint).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toZone(updated)
+	return &result, nil
+}
+
+func (c *Client) DeleteZone(ctx context.Context, accountID, containerID, workspaceID, zoneID string) error {
+	err := c.Service.Accounts.Containers.Workspaces.Zones.Delete(
+		BuildZonePath(accountID, containerID, workspaceID, zoneID),
+	).Context(ctx).Do()
+	return mapGoogleError(err)
+}
+
+func BuildZonePath(accountID, containerID, workspaceID, zoneID string) string {
+	return fmt.Sprintf("%s/zones/%s", BuildWorkspacePath(accountID, containerID, workspaceID), zoneID)
+}
+
+func zoneFromCreateConfig(config ZoneCreateConfig) *tagmanager.Zone {
+	zone := &tagmanager.Zone{Name: config.Name, Notes: config.Notes}
+	if config.BoundaryConditions != nil || config.CustomEvaluationTriggerIDs != nil {
+		zone.Boundary = &tagmanager.ZoneBoundary{
+			Condition:                 toAPIConditions(config.BoundaryConditions),
+			CustomEvaluationTriggerId: config.CustomEvaluationTriggerIDs,
+		}
+	}
+	if config.ChildContainers != nil {
+		zone.ChildContainer = toAPIChildContainers(config.ChildContainers)
+	}
+	if config.TypeRestriction != nil {
+		zone.TypeRestriction = toAPITypeRestriction(config.TypeRestriction)
+	}
+	return zone
+}
+
+func applyZoneUpdate(zone *tagmanager.Zone, config ZoneUpdateConfig) {
+	if config.Name != nil {
+		zone.Name = *config.Name
+	}
+	if config.Notes != nil {
+		zone.Notes = *config.Notes
+		if *config.Notes == "" {
+			zone.ForceSendFields = append(zone.ForceSendFields, "Notes")
+		}
+	}
+	if config.BoundaryConditions != nil || config.CustomEvaluationTriggerIDs != nil {
+		if zone.Boundary == nil {
+			zone.Boundary = &tagmanager.ZoneBoundary{}
+		}
+		if config.BoundaryConditions != nil {
+			zone.Boundary.Condition = toAPIConditions(*config.BoundaryConditions)
+			if len(*config.BoundaryConditions) == 0 {
+				zone.Boundary.ForceSendFields = append(zone.Boundary.ForceSendFields, "Condition")
+			}
+		}
+		if config.CustomEvaluationTriggerIDs != nil {
+			zone.Boundary.CustomEvaluationTriggerId = *config.CustomEvaluationTriggerIDs
+			if len(*config.CustomEvaluationTriggerIDs) == 0 {
+				zone.Boundary.ForceSendFields = append(zone.Boundary.ForceSendFields, "CustomEvaluationTriggerId")
+			}
+		}
+	}
+	if config.ChildContainers != nil {
+		zone.ChildContainer = toAPIChildContainers(*config.ChildContainers)
+		if len(*config.ChildContainers) == 0 {
+			zone.ForceSendFields = append(zone.ForceSendFields, "ChildContainer")
+		}
+	}
+	if config.TypeRestriction != nil {
+		zone.TypeRestriction = toAPITypeRestriction(config.TypeRestriction)
+	}
+}
+
+func toAPIChildContainers(children []ZoneChildContainerInput) []*tagmanager.ZoneChildContainer {
+	result := make([]*tagmanager.ZoneChildContainer, len(children))
+	for i, child := range children {
+		result[i] = &tagmanager.ZoneChildContainer{PublicId: child.PublicID, Nickname: child.Nickname}
+	}
+	return result
+}
+
+func toAPITypeRestriction(restriction *ZoneTypeRestrictionInput) *tagmanager.ZoneTypeRestriction {
+	result := &tagmanager.ZoneTypeRestriction{
+		Enable:            restriction.Enabled,
+		WhitelistedTypeId: restriction.WhitelistedTypeIDs,
+		ForceSendFields:   []string{"Enable"},
+	}
+	if len(restriction.WhitelistedTypeIDs) == 0 {
+		result.ForceSendFields = append(result.ForceSendFields, "WhitelistedTypeId")
+	}
+	return result
+}
+
+func toZone(zone *tagmanager.Zone) Zone {
+	return Zone{
+		AccountID:       zone.AccountId,
+		ContainerID:     zone.ContainerId,
+		WorkspaceID:     zone.WorkspaceId,
+		ZoneID:          zone.ZoneId,
+		Name:            zone.Name,
+		Notes:           zone.Notes,
+		Fingerprint:     zone.Fingerprint,
+		Path:            zone.Path,
+		TagManagerURL:   zone.TagManagerUrl,
+		Boundary:        zone.Boundary,
+		ChildContainers: zone.ChildContainer,
+		TypeRestriction: zone.TypeRestriction,
+	}
+}

--- a/gtm/zones_test.go
+++ b/gtm/zones_test.go
@@ -1,0 +1,201 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestListZonesPaginatesAndMapsConfiguration(t *testing.T) {
+	calls := 0
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/zones" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			fmt.Fprint(w, `{"zone":[{"accountId":"1","containerId":"2","workspaceId":"3","zoneId":"4","name":"First","fingerprint":"fp4","boundary":{"customEvaluationTriggerId":["10"]}}],"nextPageToken":"next"}`)
+		case "next":
+			fmt.Fprint(w, `{"zone":[{"zoneId":"5","name":"Second","childContainer":[{"publicId":"GTM-ABC"}]}]}`)
+		default:
+			t.Fatalf("unexpected page token %q", r.URL.Query().Get("pageToken"))
+		}
+	})
+
+	zones, err := client.ListZones(context.Background(), "1", "2", "3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || len(zones) != 2 || zones[0].Fingerprint != "fp4" || zones[0].Boundary == nil || zones[1].ChildContainers == nil {
+		t.Fatalf("calls=%d zones=%+v", calls, zones)
+	}
+}
+
+func TestGetZoneUsesExactPath(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/zones/4" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"zoneId":"4","name":"A zone","notes":"notes","fingerprint":"fp"}`)
+	})
+	zone, err := client.GetZone(context.Background(), "1", "2", "3", "4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if zone.ZoneID != "4" || zone.Name != "A zone" || zone.Notes != "notes" {
+		t.Fatalf("unexpected zone: %+v", zone)
+	}
+}
+
+func TestCreateZoneSendsConfiguration(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/zones" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		boundary, _ := body["boundary"].(map[string]any)
+		children, _ := body["childContainer"].([]any)
+		restriction, _ := body["typeRestriction"].(map[string]any)
+		if body["name"] != "Marketing zone" || len(children) != 1 || boundary["condition"] == nil || restriction["enable"] != false {
+			t.Fatalf("unexpected body: %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"zoneId":"4","name":"Marketing zone","fingerprint":"fp"}`)
+	})
+
+	zone, err := client.CreateZone(context.Background(), "1", "2", "3", ZoneCreateConfig{
+		Name: "Marketing zone",
+		BoundaryConditions: []Condition{{Type: "equals", Parameter: []Parameter{
+			{Type: "template", Key: "arg0", Value: "{{Page Hostname}}"},
+			{Type: "template", Key: "arg1", Value: "example.com"},
+		}}},
+		ChildContainers: []ZoneChildContainerInput{{PublicID: "GTM-ABC", Nickname: "Child"}},
+		TypeRestriction: &ZoneTypeRestrictionInput{Enabled: false},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if zone.ZoneID != "4" || zone.Fingerprint != "fp" {
+		t.Fatalf("unexpected zone: %+v", zone)
+	}
+}
+
+func TestUpdateZonePreservesOmittedAndClearsCollections(t *testing.T) {
+	calls := 0
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/zones/4" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			if r.Method != http.MethodGet {
+				t.Errorf("first method=%s", r.Method)
+			}
+			fmt.Fprint(w, `{"zoneId":"4","name":"Keep","notes":"clear","fingerprint":"old","boundary":{"condition":[{"type":"equals"}],"customEvaluationTriggerId":["10"]},"childContainer":[{"publicId":"GTM-OLD"}]}`)
+			return
+		}
+		if r.Method != http.MethodPut || r.URL.Query().Get("fingerprint") != "old" {
+			t.Errorf("update request: %s %s", r.Method, r.URL)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		boundary, _ := body["boundary"].(map[string]any)
+		if body["name"] != "Keep" || body["notes"] != "" {
+			t.Errorf("scalar fields not preserved/cleared: %#v", body)
+		}
+		if _, present := body["zoneId"]; present {
+			t.Errorf("update sent immutable response fields: %#v", body)
+		}
+		if conditions, ok := boundary["condition"].([]any); !ok || len(conditions) != 0 {
+			t.Errorf("conditions not explicitly cleared: %#v", boundary)
+		}
+		if children, ok := body["childContainer"].([]any); !ok || len(children) != 0 {
+			t.Errorf("children not explicitly cleared: %#v", body)
+		}
+		fmt.Fprint(w, `{"zoneId":"4","name":"Keep","fingerprint":"new"}`)
+	})
+
+	emptyNotes := ""
+	emptyConditions := []Condition{}
+	emptyChildren := []ZoneChildContainerInput{}
+	zone, err := client.UpdateZone(context.Background(), "1", "2", "3", "4", ZoneUpdateConfig{
+		Notes: &emptyNotes, BoundaryConditions: &emptyConditions, ChildContainers: &emptyChildren,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || zone.Name != "Keep" || zone.Fingerprint != "new" {
+		t.Fatalf("calls=%d zone=%+v", calls, zone)
+	}
+}
+
+func TestDeleteZoneAndErrorMapping(t *testing.T) {
+	t.Run("delete", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/zones/4" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		if err := client.DeleteZone(context.Background(), "1", "2", "3", "4"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"error":{"code":404,"message":"missing zone"}}`)
+		})
+		if _, err := client.GetZone(context.Background(), "1", "2", "3", "4"); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("error=%v, want ErrNotFound", err)
+		}
+	})
+}
+
+func TestDeleteZoneRequiresConfirmationBeforeAuth(t *testing.T) {
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	registerDeleteZone(server)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	clientSession, err := mcpClient.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+	result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{Name: "delete_zone", Arguments: map[string]any{
+		"accountId": "1", "containerId": "2", "workspaceId": "3", "zoneId": "4", "confirm": false,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("confirmation guard returned protocol error: %+v", result)
+	}
+	data, _ := json.Marshal(result.StructuredContent)
+	var output DeleteZoneOutput
+	if err := json.Unmarshal(data, &output); err != nil || output.Success || output.Message == "" {
+		t.Fatalf("unexpected output: %+v, err=%v", output, err)
+	}
+}

--- a/llms.txt
+++ b/llms.txt
@@ -48,6 +48,8 @@ Always discover IDs by listing — never guess or hardcode them.
 | `get_variable` | Get full variable details by ID |
 | `list_folders` | List folders in a workspace |
 | `get_folder_entities` | Get tags/triggers/variables in a specific folder |
+| `list_zones` | List zones in a workspace |
+| `get_zone` | Get a zone and its configuration |
 | `list_built_in_variables` | List enabled built-in variables |
 | `get_workspace_status` | Check pending changes and merge conflicts |
 
@@ -72,6 +74,9 @@ Always discover IDs by listing — never guess or hardcode them.
 | `update_account` | Rename a GTM account |
 | `enable_built_in_variables` | Enable built-in variable types |
 | `disable_built_in_variables` | Disable built-in variable types (requires `confirm: true`) |
+| `create_zone` | Create a workspace zone |
+| `update_zone` | Update selected zone fields |
+| `delete_zone` | Delete a zone (requires `confirm: true`) |
 
 ### Server-Side Container Tools
 | Tool | Purpose |


### PR DESCRIPTION
GTM API parity still lacks the workspace zone resource, so callers cannot inspect or manage zone boundaries, child containers, or tag-type restrictions.

This stacked change adds one MCP tool per normal zone operation:

- `list_zones` with full pagination
- `get_zone`
- `create_zone`
- `update_zone`, preserving omitted fields and using the current fingerprint
- `delete_zone`, guarded by `confirm: true` before authentication

Boundary conditions use the same JSON condition format as triggers. Updates can explicitly clear notes, boundary conditions, custom evaluation triggers, and child containers. `revert_zone` remains in the roadmap's later cross-resource revert slice.

Validation:

- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `git diff --check`
- Tool schema report: 64 tools, 78,734 bytes (below the 80,000-byte guard)

This PR is based on #114 and should be retargeted to `main` automatically after #114 merges. The remaining 1,266-byte schema margin means the next parity slice must first introduce the planned configurable tool groups.
