### PR TITLE
feat(mcp): add configurable tool groups

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -160,6 +160,7 @@ Map response → tool output struct
 | `SERVICE_ACCOUNT_API_KEY` | For S2S | — | Shared API key for team access |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_JSON` | For S2S | — | SA credentials (omit on GCP for Workload Identity) |
 | `LOG_LEVEL` | No | `info` | `debug` or `info` |
+| `GTM_TOOL_GROUPS` | No | current groups | Comma-separated MCP tool families, or `all` |
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -25,22 +25,22 @@ service-account authentication for self-hosted automation.
 |---|---|
 | Version in `server.json` | `1.10.1` |
 | Transport | MCP Streamable HTTP |
-| Runtime tools | 55 GTM tools and 2 utility tools |
+| Runtime tools | 64 GTM tools and 2 utility tools |
 | MCP resources | 8 resource definitions |
 | MCP prompts | 6 prompts |
-| Official GTM API coverage | 55 of 106 methods |
+| Official GTM API coverage | 64 of 106 methods |
 | Planned parity target | 101 of 106 methods |
 | Hosted endpoint | `https://mcp.gtmeditor.com` |
 
-API parity is **not complete**. The project has implemented 55 methods from
-Google's 106-method GTM v2 discovery surface. Another 46 methods are planned.
+API parity is **not complete**. The project has implemented 64 methods from
+Google's 106-method GTM v2 discovery surface. Another 37 methods are planned.
 The five `accounts.user_permissions` methods are intentionally excluded because
 granting and revoking GTM access needs a separate privilege-management design.
 
-The remaining roadmap includes workspace synchronization and preview, folder
-lifecycle operations, version state changes, container combination and tag-ID
-moves, zones, Google tag configurations, environments, destinations, and
-resource revert operations.
+The remaining roadmap includes workspace synchronization and conflict
+resolution, folder lifecycle operations, version state changes, container
+combination and tag-ID moves, Google tag configurations, environments,
+destinations, and resource revert operations.
 
 Tool count and API-method count are different. Some tools provide local
 guidance, while some helpers cover more than one Google API call.
@@ -158,10 +158,14 @@ request. Inputs and outputs are structured JSON.
 |---|---|
 | `list_workspaces` | List workspaces in a container |
 | `create_workspace` | Create a workspace |
+| `get_workspace` | Get workspace metadata and its current fingerprint |
+| `update_workspace` | Update selected workspace fields |
+| `delete_workspace` | Delete a workspace; requires `confirm: true` |
+| `quick_preview_workspace` | Compile an ephemeral preview without saving or publishing |
 | `get_workspace_status` | Show pending changes and merge conflicts |
 
-Workspace get/update/delete, quick preview, synchronization, bulk update, and
-conflict resolution are part of the remaining parity roadmap.
+Workspace synchronization, bulk update, and conflict resolution remain on the
+parity roadmap.
 
 ### Tags
 
@@ -211,6 +215,18 @@ GTM drops `autoEventFilter` for those trigger types.
 
 Folder create/get/update/delete/move/revert and built-in-variable revert remain
 on the parity roadmap.
+
+### Zones
+
+| Tool | Purpose |
+|---|---|
+| `list_zones` | List all zones across every result page |
+| `get_zone` | Get boundary, child-container, and type-restriction configuration |
+| `create_zone` | Create a workspace zone |
+| `update_zone` | Update selected fields with fingerprint concurrency control |
+| `delete_zone` | Delete a zone; requires `confirm: true` |
+
+Zone revert remains in the later cross-resource revert slice.
 
 ### Custom templates
 
@@ -419,6 +435,7 @@ When using the named volume, set `TOKEN_STORE_PATH=/data/tokens.json` in
 | `ALLOWED_HOSTS` | empty | Additional trusted hosts for Docker/internal URL resolution |
 | `TRUST_PROXY` | `false` | Trust the rightmost `X-Forwarded-For` hop for rate limiting |
 | `LOG_LEVEL` | `info` | Set `debug` for additional structured logs |
+| `GTM_TOOL_GROUPS` | current groups | Comma-separated tool families advertised through MCP |
 
 If OAuth and service-account credentials are both absent, the server starts in
 open mode. Use open mode only for isolated local development.
@@ -431,6 +448,18 @@ per-client rate limits.
 `ALLOWED_HOSTS` is a comma-separated allowlist used when the same server is
 reached through trusted internal Docker hostnames. Do not add arbitrary public
 hosts.
+
+`GTM_TOOL_GROUPS` controls schema size for clients that need only part of the
+API. Available groups are `accounts`, `workspaces`, `tags`, `triggers`,
+`variables`, `folders`, `builtins`, `zones`, `templates`, `server`, and
+`guidance`. Leaving it unset preserves the current complete 64-tool surface.
+Use `all` to include every current and future parity family, or select a subset:
+
+```text
+GTM_TOOL_GROUPS=accounts,workspaces,tags,triggers,variables
+```
+
+The two connection utility tools remain available regardless of this setting.
 
 ## Releases and deployment
 
@@ -469,11 +498,12 @@ go test ./... -count=1
 go vet ./...
 staticcheck ./...
 go run ./cmd/tool-schema-report
+go run ./cmd/tool-schema-report -groups tags,zones
 ```
 
 The schema report prints the GTM tool count, serialized `tools/list` size, token
 estimate, and largest definitions. The GTM tool surface currently serializes to
-65,549 bytes for 55 tools. A regression test enforces an 80,000-byte ceiling so
+78,734 bytes for 64 tools. A regression test enforces an 80,000-byte ceiling so
 new parity work does not silently consume unlimited model context.
 
 Pull requests run `govulncheck`, `gosec`, Gitleaks, Trivy, `staticcheck`, and
@@ -485,7 +515,7 @@ authentication internals, token persistence, and security invariants.
 
 ## Current limitations
 
-- Official GTM v2 API parity is 55/106, with a target of 101/106.
+- Official GTM v2 API parity is 64/106, with a target of 101/106.
 - The five account user-permission methods are outside the current product
   scope.
 - The server supports Streamable HTTP only. Stdio transport is planned but is

--- a/cmd/tool-schema-report/main.go
+++ b/cmd/tool-schema-report/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strings"
 	"time"
 
 	"gtm-mcp-server/gtm"
@@ -25,6 +26,7 @@ type toolSize struct {
 
 func main() {
 	top := flag.Int("top", 10, "number of largest tool definitions to print")
+	groupList := flag.String("groups", "", "comma-separated GTM tool groups; empty uses the default set")
 	flag.Parse()
 	if *top < 0 {
 		log.Fatal("-top must be zero or greater")
@@ -37,7 +39,15 @@ func main() {
 		Name:    "tool-schema-report",
 		Version: "development",
 	}, nil)
-	gtm.RegisterTools(server)
+	var names []string
+	if strings.TrimSpace(*groupList) != "" {
+		names = strings.Split(*groupList, ",")
+	}
+	groups, err := gtm.ParseToolGroups(names)
+	if err != nil {
+		log.Fatal(err)
+	}
+	gtm.RegisterToolsForGroups(server, groups)
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 	serverSession, err := server.Connect(ctx, serverTransport, nil)
@@ -94,6 +104,7 @@ func main() {
 		return sizes[i].bytes > sizes[j].bytes
 	})
 
+	fmt.Printf("groups: %s\n", strings.Join(groups.Names(), ","))
 	fmt.Printf("tools: %d\n", len(result.Tools))
 	fmt.Printf("tools/list result bytes: %d\n", len(payload))
 	fmt.Printf("estimated tokens at 4 bytes/token: %d\n", (len(payload)+3)/4)

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,9 @@ type Config struct {
 
 	// Logging
 	LogLevel string
+	// ToolGroups limits the GTM operation families advertised through MCP.
+	// Empty selects the backward-compatible default set.
+	ToolGroups []string
 
 	// Token configuration
 	AccessTokenTTL time.Duration
@@ -70,6 +73,7 @@ func Load() (*Config, error) {
 		GoogleRedirectURI:     getEnv("GOOGLE_REDIRECT_URI", ""),
 		JWTSecret:             getEnv("JWT_SECRET", ""),
 		LogLevel:              getEnv("LOG_LEVEL", "info"),
+		ToolGroups:            getEnvList("GTM_TOOL_GROUPS"),
 		AccessTokenTTL:        getEnvDuration("ACCESS_TOKEN_TTL", 8*time.Hour),
 		TokenStorePath:        getEnv("TOKEN_STORE_PATH", ""),
 		AllowedHosts:          getEnvList("ALLOWED_HOSTS"),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,3 +34,20 @@ func TestAutoRefreshMaxAge_HonoursEnv(t *testing.T) {
 		t.Errorf("AutoRefreshMaxAge = %v, want %v", cfg.AutoRefreshMaxAge, want)
 	}
 }
+
+func TestToolGroupsFromEnvironment(t *testing.T) {
+	t.Setenv("GTM_TOOL_GROUPS", "accounts, zones, tags")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"accounts", "zones", "tags"}
+	if len(cfg.ToolGroups) != len(want) {
+		t.Fatalf("ToolGroups=%v", cfg.ToolGroups)
+	}
+	for i := range want {
+		if cfg.ToolGroups[i] != want[i] {
+			t.Fatalf("ToolGroups=%v, want %v", cfg.ToolGroups, want)
+		}
+	}
+}

--- a/gtm/tool_groups_test.go
+++ b/gtm/tool_groups_test.go
@@ -1,0 +1,101 @@
+package gtm
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestParseToolGroups(t *testing.T) {
+	defaults, err := ParseToolGroups(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range defaultToolGroupNames {
+		if !defaults.enabled(name) {
+			t.Errorf("default group %q is disabled", name)
+		}
+	}
+	selected, err := ParseToolGroups([]string{" Tags ", "ZONES"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !selected.enabled("tags") || selected.enabled("accounts") || !slices.Equal(selected.Names(), []string{"tags", "zones"}) {
+		t.Fatalf("unexpected selected groups: %v", selected.Names())
+	}
+	if _, err := ParseToolGroups([]string{"typo"}); err == nil {
+		t.Fatal("unknown group was accepted")
+	}
+}
+
+func TestRegisterToolsForGroupsIsolatesSelectedFamily(t *testing.T) {
+	groups, err := ParseToolGroups([]string{"tags"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	server := mcp.NewServer(&mcp.Implementation{Name: "groups-test", Version: "1"}, nil)
+	RegisterToolsForGroups(server, groups)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	client := mcp.NewClient(&mcp.Implementation{Name: "groups-test", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(result.Tools))
+	for _, tool := range result.Tools {
+		names = append(names, tool.Name)
+	}
+	slices.Sort(names)
+	want := []string{"create_tag", "delete_tag", "get_tag", "list_tags", "update_tag"}
+	if !slices.Equal(names, want) {
+		t.Fatalf("tools=%v, want %v", names, want)
+	}
+}
+
+func TestDefaultAndAllGroupsExposeCurrentSurface(t *testing.T) {
+	defaults, _ := ParseToolGroups(nil)
+	all, _ := ParseToolGroups([]string{"all"})
+	if got, want := registeredToolCount(t, defaults), registeredToolCount(t, all); got != want || got != 64 {
+		t.Fatalf("default=%d all=%d, want both 64", got, want)
+	}
+}
+
+func registeredToolCount(t *testing.T, groups ToolGroups) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	server := mcp.NewServer(&mcp.Implementation{Name: "count-test", Version: "1"}, nil)
+	RegisterToolsForGroups(server, groups)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	client := mcp.NewClient(&mcp.Implementation{Name: "count-test", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(result.Tools)
+}

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -3,100 +3,166 @@ package gtm
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"gtm-mcp-server/auth"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// ToolGroups selects which GTM operation families appear in tools/list. The
+// server keeps resources and prompts available because they add no tool-schema
+// cost and provide documentation for whichever families are enabled.
+type ToolGroups map[string]bool
+
+var defaultToolGroupNames = []string{
+	"accounts", "workspaces", "tags", "triggers", "variables",
+	"folders", "builtins", "zones", "templates", "server", "guidance",
+}
+
+// ParseToolGroups validates GTM_TOOL_GROUPS. An empty value preserves the
+// complete pre-grouping tool surface. "all" also enables future families.
+func ParseToolGroups(names []string) (ToolGroups, error) {
+	if len(names) == 0 {
+		names = defaultToolGroupNames
+	}
+	known := make(map[string]bool, len(defaultToolGroupNames)+1)
+	for _, name := range defaultToolGroupNames {
+		known[name] = true
+	}
+	known["all"] = true
+	groups := make(ToolGroups, len(names))
+	for _, name := range names {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if !known[name] {
+			return nil, fmt.Errorf("unknown GTM tool group %q", name)
+		}
+		groups[name] = true
+	}
+	return groups, nil
+}
+
+func (groups ToolGroups) enabled(name string) bool { return groups["all"] || groups[name] }
+
+func (groups ToolGroups) Names() []string {
+	names := make([]string, 0, len(groups))
+	for name := range groups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // RegisterTools adds all GTM tools to the MCP server.
 func RegisterTools(server *mcp.Server) {
-	// Read operations
-	registerListAccounts(server)
-	registerUpdateAccount(server)
-	registerListContainers(server)
-	registerLookupContainer(server)
-	registerGetContainerSnippet(server)
-	registerListWorkspaces(server)
-	registerGetWorkspace(server)
-	registerQuickPreviewWorkspace(server)
-	registerListTags(server)
-	registerGetTag(server)
-	registerListTriggers(server)
-	registerGetTrigger(server)
-	registerListVariables(server)
-	registerGetVariable(server)
-	registerListFolders(server)
-	registerGetFolderEntities(server)
-	registerListTemplates(server)
-	registerGetTemplate(server)
-	registerListVersions(server)
-	registerGetLatestVersionHeader(server)
-	registerGetVersion(server)
-	registerGetLiveVersion(server)
-	registerListZones(server)
-	registerGetZone(server)
+	groups, err := ParseToolGroups(nil)
+	if err != nil {
+		panic(err)
+	}
+	RegisterToolsForGroups(server, groups)
+}
 
-	// Write operations
-	registerCreateTag(server)
-	registerUpdateTag(server)
-	registerDeleteTag(server)
-	registerCreateTrigger(server)
-	registerUpdateTrigger(server)
-	registerDeleteTrigger(server)
-	registerCreateVariable(server)
-	registerUpdateVariable(server)
-	registerDeleteVariable(server)
-	registerCreateContainer(server)
-	registerUpdateContainer(server)
-	registerDeleteContainer(server)
-	registerCreateWorkspace(server)
-	registerUpdateWorkspace(server)
-	registerDeleteWorkspace(server)
-	registerCreateZone(server)
-	registerUpdateZone(server)
-	registerDeleteZone(server)
+// RegisterToolsForGroups adds only the selected operation families.
+func RegisterToolsForGroups(server *mcp.Server, groups ToolGroups) {
+	if groups.enabled("accounts") {
+		registerListAccounts(server)
+		registerUpdateAccount(server)
+		registerListContainers(server)
+		registerLookupContainer(server)
+		registerGetContainerSnippet(server)
+		registerCreateContainer(server)
+		registerUpdateContainer(server)
+		registerDeleteContainer(server)
+	}
 
-	// Workspace status
-	registerGetWorkspaceStatus(server)
+	if groups.enabled("workspaces") {
+		registerListWorkspaces(server)
+		registerGetWorkspace(server)
+		registerQuickPreviewWorkspace(server)
+		registerCreateWorkspace(server)
+		registerUpdateWorkspace(server)
+		registerDeleteWorkspace(server)
+		registerGetWorkspaceStatus(server)
+		registerListVersions(server)
+		registerGetLatestVersionHeader(server)
+		registerGetVersion(server)
+		registerGetLiveVersion(server)
+		registerCreateVersion(server)
+		registerPublishVersion(server)
+	}
 
-	// Version operations
-	registerCreateVersion(server)
-	registerPublishVersion(server)
+	if groups.enabled("tags") {
+		registerListTags(server)
+		registerGetTag(server)
+		registerCreateTag(server)
+		registerUpdateTag(server)
+		registerDeleteTag(server)
+	}
 
-	// Template operations
-	registerImportGalleryTemplate(server)
-	registerCreateTemplate(server)
-	registerUpdateTemplate(server)
-	registerDeleteTemplate(server)
+	if groups.enabled("triggers") {
+		registerListTriggers(server)
+		registerGetTrigger(server)
+		registerCreateTrigger(server)
+		registerUpdateTrigger(server)
+		registerDeleteTrigger(server)
+	}
 
-	// Built-in variables
-	registerListBuiltInVariables(server)
-	registerEnableBuiltInVariables(server)
-	registerDisableBuiltInVariables(server)
+	if groups.enabled("variables") {
+		registerListVariables(server)
+		registerGetVariable(server)
+		registerCreateVariable(server)
+		registerUpdateVariable(server)
+		registerDeleteVariable(server)
+	}
 
-	// Clients (server-side containers)
-	registerListClients(server)
-	registerGetClient(server)
-	registerCreateClient(server)
-	registerUpdateClient(server)
-	registerDeleteClient(server)
+	if groups.enabled("folders") {
+		registerListFolders(server)
+		registerGetFolderEntities(server)
+	}
 
-	// Transformations (server-side containers)
-	registerListTransformations(server)
-	registerGetTransformation(server)
-	registerCreateTransformation(server)
-	registerUpdateTransformation(server)
-	registerDeleteTransformation(server)
+	if groups.enabled("zones") {
+		registerListZones(server)
+		registerGetZone(server)
+		registerCreateZone(server)
+		registerUpdateZone(server)
+		registerDeleteZone(server)
+	}
 
-	// Templates (help LLMs with correct parameter formats)
-	registerGetTagTemplates(server)
-	registerGetTriggerTemplates(server)
+	if groups.enabled("builtins") {
+		registerListBuiltInVariables(server)
+		registerEnableBuiltInVariables(server)
+		registerDisableBuiltInVariables(server)
+	}
 
-	// Resources (URI-based read access)
+	if groups.enabled("templates") {
+		registerListTemplates(server)
+		registerGetTemplate(server)
+		registerImportGalleryTemplate(server)
+		registerCreateTemplate(server)
+		registerUpdateTemplate(server)
+		registerDeleteTemplate(server)
+	}
+
+	if groups.enabled("server") {
+		registerListClients(server)
+		registerGetClient(server)
+		registerCreateClient(server)
+		registerUpdateClient(server)
+		registerDeleteClient(server)
+		registerListTransformations(server)
+		registerGetTransformation(server)
+		registerCreateTransformation(server)
+		registerUpdateTransformation(server)
+		registerDeleteTransformation(server)
+	}
+
+	if groups.enabled("guidance") {
+		registerGetTagTemplates(server)
+		registerGetTriggerTemplates(server)
+	}
+
 	RegisterResources(server)
-
-	// Prompts (template workflows)
 	RegisterPrompts(server)
 }
 

--- a/main.go
+++ b/main.go
@@ -63,8 +63,13 @@ func main() {
 	// Add logging middleware
 	server.AddReceivingMiddleware(middleware.NewLoggingMiddleware(logger))
 
-	// Register tools
-	registerTools(server)
+	toolGroups, err := gtm.ParseToolGroups(cfg.ToolGroups)
+	if err != nil {
+		logger.Error("invalid tool group configuration", "error", err)
+		os.Exit(1)
+	}
+	registerTools(server, toolGroups)
+	logger.Info("registered GTM tool groups", "groups", toolGroups.Names())
 
 	// TODO(stdio): branch here on the configured transport. In stdio mode,
 	// inject a token source at auth.SATokenSourceKey via receiving middleware
@@ -267,9 +272,9 @@ func main() {
 }
 
 // registerTools adds MCP tools to the server.
-func registerTools(server *mcp.Server) {
+func registerTools(server *mcp.Server, groups gtm.ToolGroups) {
 	registerUtilityTools(server)
-	gtm.RegisterTools(server)
+	gtm.RegisterToolsForGroups(server, groups)
 }
 
 // maxBytesHandler wraps an http.Handler with a request body size limit.


### PR DESCRIPTION
The parity roadmap has reached 78,734 bytes for 64 GTM tool definitions, leaving only 1,266 bytes under the schema guard. Additional API families need a way to remain available without forcing every client to load every schema.

This change adds `GTM_TOOL_GROUPS` with validated operation-family selection. Leaving it unset preserves the current 64-tool GTM surface. `all` enables every current and future family, while deployments can select any combination of `accounts`, `workspaces`, `tags`, `triggers`, `variables`, `folders`, `builtins`, `zones`, `templates`, `server`, and `guidance`. Connection utility tools, MCP resources, and prompts remain available.

The schema report accepts the same group selection through `-groups`. For example, `tags,zones` advertises 10 GTM tools in 17,521 bytes instead of the 78,734-byte default.

The README is also brought forward after #114 and #115: it documents the workspace and zone tools and records 64/106 official GTM API coverage.

Validation:

- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `git diff --check`
- Default schema: 64 tools, 78,734 bytes
- `tags,zones` schema: 10 tools, 17,521 bytes
