### PR TITLE
feat: add GTM environment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,22 @@ service-account authentication for self-hosted automation.
 |---|---|
 | Version in `server.json` | `1.10.1` |
 | Transport | MCP Streamable HTTP |
-| Runtime tools | 64 GTM tools and 2 utility tools |
+| Runtime tools | 64 GTM tools by default; 70 with `GTM_TOOL_GROUPS=all`, plus 2 utility tools |
 | MCP resources | 8 resource definitions |
 | MCP prompts | 6 prompts |
-| Official GTM API coverage | 64 of 106 methods |
+| Official GTM API coverage | 70 of 106 methods |
 | Planned parity target | 101 of 106 methods |
 | Hosted endpoint | `https://mcp.gtmeditor.com` |
 
-API parity is **not complete**. The project has implemented 64 methods from
-Google's 106-method GTM v2 discovery surface. Another 37 methods are planned.
+API parity is **not complete**. The project has implemented 70 methods from
+Google's 106-method GTM v2 discovery surface. Another 31 methods are planned.
 The five `accounts.user_permissions` methods are intentionally excluded because
 granting and revoking GTM access needs a separate privilege-management design.
 
 The remaining roadmap includes workspace synchronization and conflict
 resolution, folder lifecycle operations, version state changes, container
-combination and tag-ID moves, Google tag configurations, environments,
-destinations, and resource revert operations.
+combination and tag-ID moves, Google tag configurations, destinations, and
+resource revert operations.
 
 Tool count and API-method count are different. Some tools provide local
 guidance, while some helpers cover more than one Google API call.
@@ -227,6 +227,23 @@ on the parity roadmap.
 | `delete_zone` | Delete a zone; requires `confirm: true` |
 
 Zone revert remains in the later cross-resource revert slice.
+
+### Environments
+
+The `environments` tool group is optional. Enable it with
+`GTM_TOOL_GROUPS=all` or add `environments` to an explicit group list.
+
+| Tool | Purpose |
+|---|---|
+| `list_environments` | List all container environments across every result page |
+| `get_environment` | Get environment configuration and authorization metadata |
+| `create_environment` | Create a user environment |
+| `update_environment` | Update selected fields with fingerprint concurrency control |
+| `reauthorize_environment` | Rotate the authorization code; requires `confirm: true` |
+| `delete_environment` | Delete a user environment; requires `confirm: true` |
+
+The Live and Latest environments are managed by GTM. Create, update, and
+delete operations apply to user environments.
 
 ### Custom templates
 
@@ -451,9 +468,10 @@ hosts.
 
 `GTM_TOOL_GROUPS` controls schema size for clients that need only part of the
 API. Available groups are `accounts`, `workspaces`, `tags`, `triggers`,
-`variables`, `folders`, `builtins`, `zones`, `templates`, `server`, and
-`guidance`. Leaving it unset preserves the current complete 64-tool surface.
-Use `all` to include every current and future parity family, or select a subset:
+`variables`, `folders`, `builtins`, `zones`, `templates`, `server`, `guidance`,
+and `environments`. Leaving it unset preserves the established 64-tool surface.
+The newer `environments` group is opt-in. Use `all` to include every current
+and future parity family, or select a subset:
 
 ```text
 GTM_TOOL_GROUPS=accounts,workspaces,tags,triggers,variables
@@ -502,9 +520,10 @@ go run ./cmd/tool-schema-report -groups tags,zones
 ```
 
 The schema report prints the GTM tool count, serialized `tools/list` size, token
-estimate, and largest definitions. The GTM tool surface currently serializes to
+estimate, and largest definitions. The default GTM tool surface serializes to
 78,734 bytes for 64 tools. A regression test enforces an 80,000-byte ceiling so
-new parity work does not silently consume unlimited model context.
+new parity work does not silently consume unlimited model context. The `all`
+group exposes 70 GTM tools, including environments.
 
 Pull requests run `govulncheck`, `gosec`, Gitleaks, Trivy, `staticcheck`, and
 CodeQL. Request-level GTM tests use local fake Google endpoints. Mutating live
@@ -515,7 +534,7 @@ authentication internals, token persistence, and security invariants.
 
 ## Current limitations
 
-- Official GTM v2 API parity is 64/106, with a target of 101/106.
+- Official GTM v2 API parity is 70/106, with a target of 101/106.
 - The five account user-permission methods are outside the current product
   scope.
 - The server supports Streamable HTTP only. Stdio transport is planned but is

--- a/gtm/environments.go
+++ b/gtm/environments.go
@@ -1,0 +1,174 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+type Environment struct {
+	AccountID              string `json:"accountId"`
+	ContainerID            string `json:"containerId"`
+	EnvironmentID          string `json:"environmentId"`
+	Name                   string `json:"name"`
+	Description            string `json:"description,omitempty"`
+	Type                   string `json:"type"`
+	URL                    string `json:"url,omitempty"`
+	EnableDebug            bool   `json:"enableDebug"`
+	AuthorizationCode      string `json:"authorizationCode,omitempty"`
+	AuthorizationTimestamp string `json:"authorizationTimestamp,omitempty"`
+	ContainerVersionID     string `json:"containerVersionId,omitempty"`
+	WorkspaceID            string `json:"workspaceId,omitempty"`
+	Fingerprint            string `json:"fingerprint"`
+	Path                   string `json:"path"`
+	TagManagerURL          string `json:"tagManagerUrl,omitempty"`
+}
+
+type EnvironmentCreateConfig struct {
+	Name, Description, URL string
+	EnableDebug            bool
+}
+
+type EnvironmentUpdateConfig struct {
+	Name, Description, URL          *string
+	EnableDebug                     *bool
+	ContainerVersionID, WorkspaceID *string
+}
+
+func (c *Client) ListEnvironments(ctx context.Context, accountID, containerID string) ([]Environment, error) {
+	parent := BuildContainerPath(accountID, containerID)
+	result := make([]Environment, 0)
+	pageToken := ""
+	for {
+		response, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListEnvironmentsResponse, error) {
+			return c.Service.Accounts.Containers.Environments.List(parent).PageToken(pageToken).Context(ctx).Do()
+		})
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		for _, environment := range response.Environment {
+			result = append(result, toEnvironment(environment))
+		}
+		if response.NextPageToken == "" {
+			return result, nil
+		}
+		pageToken = response.NextPageToken
+	}
+}
+
+func (c *Client) GetEnvironment(ctx context.Context, accountID, containerID, environmentID string) (*Environment, error) {
+	path := BuildEnvironmentPath(accountID, containerID, environmentID)
+	environment, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Environment, error) {
+		return c.Service.Accounts.Containers.Environments.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toEnvironment(environment)
+	return &result, nil
+}
+
+func (c *Client) CreateEnvironment(ctx context.Context, accountID, containerID string, config EnvironmentCreateConfig) (*Environment, error) {
+	body := &tagmanager.Environment{
+		Name: config.Name, Description: config.Description, Url: config.URL,
+		EnableDebug: config.EnableDebug, Type: "user",
+	}
+	if !config.EnableDebug {
+		body.ForceSendFields = append(body.ForceSendFields, "EnableDebug")
+	}
+	environment, err := c.Service.Accounts.Containers.Environments.Create(BuildContainerPath(accountID, containerID), body).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toEnvironment(environment)
+	return &result, nil
+}
+
+func (c *Client) UpdateEnvironment(ctx context.Context, accountID, containerID, environmentID string, config EnvironmentUpdateConfig) (*Environment, error) {
+	path := BuildEnvironmentPath(accountID, containerID, environmentID)
+	current, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Environment, error) {
+		return c.Service.Accounts.Containers.Environments.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	body := &tagmanager.Environment{
+		Name: current.Name, Description: current.Description, Url: current.Url,
+		EnableDebug: current.EnableDebug, ContainerVersionId: current.ContainerVersionId,
+		WorkspaceId: current.WorkspaceId, Type: current.Type,
+	}
+	applyEnvironmentUpdate(body, config)
+	environment, err := c.Service.Accounts.Containers.Environments.Update(path, body).Fingerprint(current.Fingerprint).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toEnvironment(environment)
+	return &result, nil
+}
+
+func (c *Client) ReauthorizeEnvironment(ctx context.Context, accountID, containerID, environmentID string) (*Environment, error) {
+	path := BuildEnvironmentPath(accountID, containerID, environmentID)
+	environment, err := c.Service.Accounts.Containers.Environments.Reauthorize(path, &tagmanager.Environment{}).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toEnvironment(environment)
+	return &result, nil
+}
+
+func (c *Client) DeleteEnvironment(ctx context.Context, accountID, containerID, environmentID string) error {
+	return mapGoogleError(c.Service.Accounts.Containers.Environments.Delete(BuildEnvironmentPath(accountID, containerID, environmentID)).Context(ctx).Do())
+}
+
+func BuildEnvironmentPath(accountID, containerID, environmentID string) string {
+	return fmt.Sprintf("%s/environments/%s", BuildContainerPath(accountID, containerID), environmentID)
+}
+
+func applyEnvironmentUpdate(environment *tagmanager.Environment, config EnvironmentUpdateConfig) {
+	if config.Name != nil {
+		environment.Name = *config.Name
+	}
+	if config.Description != nil {
+		environment.Description = *config.Description
+		if *config.Description == "" {
+			environment.ForceSendFields = append(environment.ForceSendFields, "Description")
+		}
+	}
+	if config.URL != nil {
+		environment.Url = *config.URL
+		if *config.URL == "" {
+			environment.ForceSendFields = append(environment.ForceSendFields, "Url")
+		}
+	}
+	if config.EnableDebug != nil {
+		environment.EnableDebug = *config.EnableDebug
+		if !*config.EnableDebug {
+			environment.ForceSendFields = append(environment.ForceSendFields, "EnableDebug")
+		}
+	}
+	if config.ContainerVersionID != nil {
+		environment.ContainerVersionId = *config.ContainerVersionID
+		if *config.ContainerVersionID == "" {
+			environment.ForceSendFields = append(environment.ForceSendFields, "ContainerVersionId")
+		}
+	}
+	if config.WorkspaceID != nil {
+		environment.WorkspaceId = *config.WorkspaceID
+		if *config.WorkspaceID == "" {
+			environment.ForceSendFields = append(environment.ForceSendFields, "WorkspaceId")
+		}
+	}
+}
+
+func toEnvironment(environment *tagmanager.Environment) Environment {
+	return Environment{
+		AccountID: environment.AccountId, ContainerID: environment.ContainerId,
+		EnvironmentID: environment.EnvironmentId, Name: environment.Name,
+		Description: environment.Description, Type: environment.Type, URL: environment.Url,
+		EnableDebug: environment.EnableDebug, AuthorizationCode: environment.AuthorizationCode,
+		AuthorizationTimestamp: environment.AuthorizationTimestamp,
+		ContainerVersionID:     environment.ContainerVersionId, WorkspaceID: environment.WorkspaceId,
+		Fingerprint: environment.Fingerprint, Path: environment.Path, TagManagerURL: environment.TagManagerUrl,
+	}
+}

--- a/gtm/environments_test.go
+++ b/gtm/environments_test.go
@@ -1,0 +1,203 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestListEnvironmentsPaginatesAndMapsFields(t *testing.T) {
+	calls := 0
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/environments" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			fmt.Fprint(w, `{"environment":[{"accountId":"1","containerId":"2","environmentId":"3","name":"QA","type":"user","url":"https://example.com","enableDebug":true,"authorizationCode":"code","fingerprint":"fp"}],"nextPageToken":"next"}`)
+		case "next":
+			fmt.Fprint(w, `{"environment":[{"environmentId":"4","name":"Live","type":"live","containerVersionId":"9"}]}`)
+		default:
+			t.Fatalf("unexpected page token %q", r.URL.Query().Get("pageToken"))
+		}
+	})
+
+	environments, err := client.ListEnvironments(context.Background(), "1", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || len(environments) != 2 || environments[0].AuthorizationCode != "code" || environments[1].ContainerVersionID != "9" {
+		t.Fatalf("calls=%d environments=%+v", calls, environments)
+	}
+}
+
+func TestGetEnvironmentUsesExactPath(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/environments/3" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"environmentId":"3","name":"QA","type":"user","workspaceId":"7","fingerprint":"fp"}`)
+	})
+	environment, err := client.GetEnvironment(context.Background(), "1", "2", "3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if environment.EnvironmentID != "3" || environment.Name != "QA" || environment.WorkspaceID != "7" {
+		t.Fatalf("unexpected environment: %+v", environment)
+	}
+}
+
+func TestCreateEnvironmentSendsUserConfiguration(t *testing.T) {
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/environments" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["name"] != "QA" || body["type"] != "user" || body["enableDebug"] != false || body["url"] != "https://example.com" {
+			t.Fatalf("unexpected body: %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"environmentId":"3","name":"QA","type":"user","fingerprint":"fp"}`)
+	})
+
+	environment, err := client.CreateEnvironment(context.Background(), "1", "2", EnvironmentCreateConfig{
+		Name: "QA", Description: "Quality assurance", URL: "https://example.com", EnableDebug: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if environment.EnvironmentID != "3" || environment.Fingerprint != "fp" {
+		t.Fatalf("unexpected environment: %+v", environment)
+	}
+}
+
+func TestUpdateEnvironmentPreservesOmittedAndClearsFields(t *testing.T) {
+	calls := 0
+	client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/environments/3" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			if r.Method != http.MethodGet {
+				t.Errorf("first method=%s", r.Method)
+			}
+			fmt.Fprint(w, `{"environmentId":"3","name":"Keep","description":"clear","url":"https://old.example","enableDebug":true,"containerVersionId":"8","workspaceId":"7","type":"user","fingerprint":"old"}`)
+			return
+		}
+		if r.Method != http.MethodPut || r.URL.Query().Get("fingerprint") != "old" {
+			t.Errorf("update request: %s %s", r.Method, r.URL)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["name"] != "Keep" || body["description"] != "" || body["url"] != "" || body["enableDebug"] != false || body["workspaceId"] != "" {
+			t.Fatalf("fields not preserved or cleared: %#v", body)
+		}
+		if body["containerVersionId"] != "8" {
+			t.Errorf("omitted containerVersionId was not preserved: %#v", body)
+		}
+		if _, present := body["environmentId"]; present {
+			t.Errorf("update sent immutable response fields: %#v", body)
+		}
+		fmt.Fprint(w, `{"environmentId":"3","name":"Keep","fingerprint":"new"}`)
+	})
+
+	empty := ""
+	disableDebug := false
+	environment, err := client.UpdateEnvironment(context.Background(), "1", "2", "3", EnvironmentUpdateConfig{
+		Description: &empty, URL: &empty, EnableDebug: &disableDebug, WorkspaceID: &empty,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || environment.Fingerprint != "new" {
+		t.Fatalf("calls=%d environment=%+v", calls, environment)
+	}
+}
+
+func TestReauthorizeAndDeleteEnvironmentUseExactPaths(t *testing.T) {
+	t.Run("reauthorize", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/environments/3:reauthorize" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"environmentId":"3","authorizationCode":"new-code"}`)
+		})
+		environment, err := client.ReauthorizeEnvironment(context.Background(), "1", "2", "3")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if environment.AuthorizationCode != "new-code" {
+			t.Fatalf("unexpected environment: %+v", environment)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/environments/3" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		if err := client.DeleteEnvironment(context.Background(), "1", "2", "3"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"error":{"code":404,"message":"missing environment"}}`)
+		})
+		if _, err := client.GetEnvironment(context.Background(), "1", "2", "3"); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("error=%v, want ErrNotFound", err)
+		}
+	})
+}
+
+func TestEnvironmentConfirmationGuardsRunBeforeAuth(t *testing.T) {
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	registerReauthorizeEnvironment(server)
+	registerDeleteEnvironment(server)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	for _, name := range []string{"reauthorize_environment", "delete_environment"} {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: map[string]any{
+			"accountId": "1", "containerId": "2", "environmentId": "3", "confirm": false,
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.IsError {
+			t.Fatalf("%s confirmation guard returned protocol error: %+v", name, result)
+		}
+	}
+}

--- a/gtm/tool_environments.go
+++ b/gtm/tool_environments.go
@@ -1,0 +1,176 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type EnvironmentInput struct {
+	AccountID     string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID   string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	EnvironmentID string `json:"environmentId" jsonschema:"description:The GTM environment ID"`
+}
+
+type EnvironmentContainerInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+}
+
+type ListEnvironmentsOutput struct {
+	Environments []Environment `json:"environments"`
+}
+
+type EnvironmentOutput struct {
+	Environment Environment `json:"environment"`
+}
+
+type EnvironmentMutationOutput struct {
+	Success     bool        `json:"success"`
+	Environment Environment `json:"environment"`
+	Message     string      `json:"message"`
+}
+
+type CreateEnvironmentInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	Name        string `json:"name" jsonschema:"description:Environment display name"`
+	Description string `json:"description,omitempty" jsonschema:"description:Optional environment description"`
+	URL         string `json:"url,omitempty" jsonschema:"description:Optional default preview URL"`
+	EnableDebug bool   `json:"enableDebug,omitempty" jsonschema:"description:Enable debugging by default"`
+}
+
+type UpdateEnvironmentInput struct {
+	EnvironmentInput
+	Name               *string `json:"name,omitempty" jsonschema:"description:New name; omit to preserve"`
+	Description        *string `json:"description,omitempty" jsonschema:"description:New description; omit to preserve or pass empty to clear"`
+	URL                *string `json:"url,omitempty" jsonschema:"description:New preview URL; omit to preserve or pass empty to clear"`
+	EnableDebug        *bool   `json:"enableDebug,omitempty" jsonschema:"description:New debug setting; omit to preserve"`
+	ContainerVersionID *string `json:"containerVersionId,omitempty" jsonschema:"description:Container version exposed by this environment; omit to preserve or pass empty to clear"`
+	WorkspaceID        *string `json:"workspaceId,omitempty" jsonschema:"description:Workspace exposed by this environment; omit to preserve or pass empty to clear"`
+}
+
+type ConfirmEnvironmentInput struct {
+	EnvironmentInput
+	Confirm bool `json:"confirm" jsonschema:"description:Must be true to confirm the operation"`
+}
+
+type DeleteEnvironmentOutput struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+func registerListEnvironments(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "list_environments", Description: "List all GTM environments in a container across every result page."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input EnvironmentContainerInput) (*mcp.CallToolResult, ListEnvironmentsOutput, error) {
+			cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+			if err != nil {
+				return nil, ListEnvironmentsOutput{}, err
+			}
+			environments, err := cc.Client.ListEnvironments(ctx, cc.AccountID, cc.ContainerID)
+			return nil, ListEnvironmentsOutput{Environments: environments}, err
+		})
+}
+
+func registerGetEnvironment(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "get_environment", Description: "Get a GTM environment, including its preview URL and authorization metadata."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input EnvironmentInput) (*mcp.CallToolResult, EnvironmentOutput, error) {
+			cc, err := resolveEnvironment(ctx, input)
+			if err != nil {
+				return nil, EnvironmentOutput{}, err
+			}
+			environment, err := cc.Client.GetEnvironment(ctx, cc.AccountID, cc.ContainerID, input.EnvironmentID)
+			if err != nil {
+				return nil, EnvironmentOutput{}, err
+			}
+			return nil, EnvironmentOutput{Environment: *environment}, nil
+		})
+}
+
+func registerCreateEnvironment(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "create_environment", Description: "Create a user GTM environment in a container."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input CreateEnvironmentInput) (*mcp.CallToolResult, EnvironmentMutationOutput, error) {
+			if strings.TrimSpace(input.Name) == "" {
+				return nil, EnvironmentMutationOutput{}, fmt.Errorf("name is required")
+			}
+			cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+			if err != nil {
+				return nil, EnvironmentMutationOutput{}, err
+			}
+			environment, err := cc.Client.CreateEnvironment(ctx, cc.AccountID, cc.ContainerID, EnvironmentCreateConfig{
+				Name: input.Name, Description: input.Description, URL: input.URL, EnableDebug: input.EnableDebug,
+			})
+			if err != nil {
+				return nil, EnvironmentMutationOutput{}, err
+			}
+			return nil, EnvironmentMutationOutput{Success: true, Environment: *environment, Message: "Environment created successfully"}, nil
+		})
+}
+
+func registerUpdateEnvironment(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "update_environment", Description: "Update selected GTM environment fields while preserving omitted values and checking its fingerprint."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateEnvironmentInput) (*mcp.CallToolResult, EnvironmentMutationOutput, error) {
+			if input.Name == nil && input.Description == nil && input.URL == nil && input.EnableDebug == nil && input.ContainerVersionID == nil && input.WorkspaceID == nil {
+				return nil, EnvironmentMutationOutput{}, fmt.Errorf("provide at least one field to update")
+			}
+			if input.Name != nil && strings.TrimSpace(*input.Name) == "" {
+				return nil, EnvironmentMutationOutput{}, fmt.Errorf("name cannot be empty")
+			}
+			cc, err := resolveEnvironment(ctx, input.EnvironmentInput)
+			if err != nil {
+				return nil, EnvironmentMutationOutput{}, err
+			}
+			environment, err := cc.Client.UpdateEnvironment(ctx, cc.AccountID, cc.ContainerID, input.EnvironmentID, EnvironmentUpdateConfig{
+				Name: input.Name, Description: input.Description, URL: input.URL, EnableDebug: input.EnableDebug,
+				ContainerVersionID: input.ContainerVersionID, WorkspaceID: input.WorkspaceID,
+			})
+			if err != nil {
+				return nil, EnvironmentMutationOutput{}, err
+			}
+			return nil, EnvironmentMutationOutput{Success: true, Environment: *environment, Message: "Environment updated successfully"}, nil
+		})
+}
+
+func registerReauthorizeEnvironment(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "reauthorize_environment", Description: "Generate a new authorization code for a GTM environment. Requires confirm: true because the previous code becomes invalid."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input ConfirmEnvironmentInput) (*mcp.CallToolResult, EnvironmentMutationOutput, error) {
+			if !input.Confirm {
+				return nil, EnvironmentMutationOutput{Message: "Environment reauthorization requires confirm: true"}, nil
+			}
+			cc, err := resolveEnvironment(ctx, input.EnvironmentInput)
+			if err != nil {
+				return nil, EnvironmentMutationOutput{}, err
+			}
+			environment, err := cc.Client.ReauthorizeEnvironment(ctx, cc.AccountID, cc.ContainerID, input.EnvironmentID)
+			if err != nil {
+				return nil, EnvironmentMutationOutput{}, err
+			}
+			return nil, EnvironmentMutationOutput{Success: true, Environment: *environment, Message: "Environment reauthorized successfully"}, nil
+		})
+}
+
+func registerDeleteEnvironment(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "delete_environment", Description: "Delete a user GTM environment. Requires confirm: true."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input ConfirmEnvironmentInput) (*mcp.CallToolResult, DeleteEnvironmentOutput, error) {
+			if !input.Confirm {
+				return nil, DeleteEnvironmentOutput{Message: "Environment deletion requires confirm: true"}, nil
+			}
+			cc, err := resolveEnvironment(ctx, input.EnvironmentInput)
+			if err != nil {
+				return nil, DeleteEnvironmentOutput{}, err
+			}
+			if err := cc.Client.DeleteEnvironment(ctx, cc.AccountID, cc.ContainerID, input.EnvironmentID); err != nil {
+				return nil, DeleteEnvironmentOutput{}, err
+			}
+			return nil, DeleteEnvironmentOutput{Success: true, Message: "Environment deleted successfully"}, nil
+		})
+}
+
+func resolveEnvironment(ctx context.Context, input EnvironmentInput) (*ContainerContext, error) {
+	if strings.TrimSpace(input.EnvironmentID) == "" {
+		return nil, fmt.Errorf("environment ID is required")
+	}
+	return resolveContainer(ctx, input.AccountID, input.ContainerID)
+}

--- a/gtm/tool_groups_test.go
+++ b/gtm/tool_groups_test.go
@@ -29,6 +29,10 @@ func TestParseToolGroups(t *testing.T) {
 	if _, err := ParseToolGroups([]string{"typo"}); err == nil {
 		t.Fatal("unknown group was accepted")
 	}
+	optional, err := ParseToolGroups([]string{"environments"})
+	if err != nil || !optional.enabled("environments") {
+		t.Fatalf("optional group not accepted: %v, %v", optional, err)
+	}
 }
 
 func TestRegisterToolsForGroupsIsolatesSelectedFamily(t *testing.T) {
@@ -67,11 +71,14 @@ func TestRegisterToolsForGroupsIsolatesSelectedFamily(t *testing.T) {
 	}
 }
 
-func TestDefaultAndAllGroupsExposeCurrentSurface(t *testing.T) {
+func TestDefaultPreservesSurfaceAndAllIncludesOptionalGroups(t *testing.T) {
 	defaults, _ := ParseToolGroups(nil)
 	all, _ := ParseToolGroups([]string{"all"})
-	if got, want := registeredToolCount(t, defaults), registeredToolCount(t, all); got != want || got != 64 {
-		t.Fatalf("default=%d all=%d, want both 64", got, want)
+	if got := registeredToolCount(t, defaults); got != 64 {
+		t.Fatalf("default=%d, want 64", got)
+	}
+	if got := registeredToolCount(t, all); got != 70 {
+		t.Fatalf("all=%d, want 70", got)
 	}
 }
 

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -21,14 +21,19 @@ var defaultToolGroupNames = []string{
 	"folders", "builtins", "zones", "templates", "server", "guidance",
 }
 
+var optionalToolGroupNames = []string{"environments"}
+
 // ParseToolGroups validates GTM_TOOL_GROUPS. An empty value preserves the
 // complete pre-grouping tool surface. "all" also enables future families.
 func ParseToolGroups(names []string) (ToolGroups, error) {
 	if len(names) == 0 {
 		names = defaultToolGroupNames
 	}
-	known := make(map[string]bool, len(defaultToolGroupNames)+1)
+	known := make(map[string]bool, len(defaultToolGroupNames)+len(optionalToolGroupNames)+1)
 	for _, name := range defaultToolGroupNames {
+		known[name] = true
+	}
+	for _, name := range optionalToolGroupNames {
 		known[name] = true
 	}
 	known["all"] = true
@@ -127,6 +132,15 @@ func RegisterToolsForGroups(server *mcp.Server, groups ToolGroups) {
 		registerCreateZone(server)
 		registerUpdateZone(server)
 		registerDeleteZone(server)
+	}
+
+	if groups.enabled("environments") {
+		registerListEnvironments(server)
+		registerGetEnvironment(server)
+		registerCreateEnvironment(server)
+		registerUpdateEnvironment(server)
+		registerReauthorizeEnvironment(server)
+		registerDeleteEnvironment(server)
 	}
 
 	if groups.enabled("builtins") {

--- a/llms.txt
+++ b/llms.txt
@@ -50,6 +50,8 @@ Always discover IDs by listing — never guess or hardcode them.
 | `get_folder_entities` | Get tags/triggers/variables in a specific folder |
 | `list_zones` | List zones in a workspace |
 | `get_zone` | Get a zone and its configuration |
+| `list_environments` | List container environments (optional `environments` group) |
+| `get_environment` | Get an environment and authorization metadata |
 | `list_built_in_variables` | List enabled built-in variables |
 | `get_workspace_status` | Check pending changes and merge conflicts |
 
@@ -71,6 +73,10 @@ Always discover IDs by listing — never guess or hardcode them.
 | `create_workspace` | Create a new workspace |
 | `update_workspace` | Update a workspace name or description |
 | `delete_workspace` | Delete a workspace and pending changes (requires `confirm: true`) |
+| `create_environment` | Create a user environment |
+| `update_environment` | Update a user environment with fingerprint protection |
+| `reauthorize_environment` | Rotate an environment authorization code (requires `confirm: true`) |
+| `delete_environment` | Delete a user environment (requires `confirm: true`) |
 | `update_account` | Rename a GTM account |
 | `enable_built_in_variables` | Enable built-in variable types |
 | `disable_built_in_variables` | Disable built-in variable types (requires `confirm: true`) |


### PR DESCRIPTION
Adds the complete six-method GTM environments family and raises official API coverage from 64/106 to 70/106.

The new optional `environments` tool group supports paginated listing, reads, user-environment creation, fingerprint-protected partial updates, authorization-code rotation, and deletion. Reauthorization and deletion require `confirm: true`; omitted update fields are preserved and empty values are sent explicitly when clearing supported fields.

Validation:

- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- schema report: default remains 64 tools / 78,734 bytes; `all` is 70 tools / 87,074 bytes
