### PR TITLE
feat: add container administration APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,21 @@ service-account authentication for self-hosted automation.
 |---|---|
 | Version in `server.json` | `1.10.1` |
 | Transport | MCP Streamable HTTP |
-| Runtime tools | 64 GTM tools by default; 70 with `GTM_TOOL_GROUPS=all`, plus 2 utility tools |
+| Runtime tools | 64 GTM tools by default; 80 with `GTM_TOOL_GROUPS=all`, plus 2 utility tools |
 | MCP resources | 8 resource definitions |
 | MCP prompts | 6 prompts |
-| Official GTM API coverage | 70 of 106 methods |
+| Official GTM API coverage | 80 of 106 methods |
 | Planned parity target | 101 of 106 methods |
 | Hosted endpoint | `https://mcp.gtmeditor.com` |
 
-API parity is **not complete**. The project has implemented 70 methods from
-Google's 106-method GTM v2 discovery surface. Another 31 methods are planned.
+API parity is **not complete**. The project has implemented 80 methods from
+Google's 106-method GTM v2 discovery surface. Another 21 methods are planned.
 The five `accounts.user_permissions` methods are intentionally excluded because
 granting and revoking GTM access needs a separate privilege-management design.
 
 The remaining roadmap includes workspace synchronization and conflict
-resolution, folder lifecycle operations, version state changes, container
-combination and tag-ID moves, Google tag configurations, destinations, and
-resource revert operations.
+resolution, folder lifecycle operations, version state changes, and resource
+revert operations.
 
 Tool count and API-method count are different. Some tools provide local
 guidance, while some helpers cover more than one Google API call.
@@ -151,6 +150,8 @@ request. Inputs and outputs are structured JSON.
 | `create_container` | Create a web, app, AMP, or server container |
 | `update_container` | Rename a container while preserving its other settings |
 | `delete_container` | Permanently delete a container; requires `confirm: true` |
+| `combine_containers` | Merge a source container into a target; requires `confirm: true` |
+| `move_tag_id` | Move a tag ID into a new container; requires confirmation and terms acceptance |
 
 ### Workspaces
 
@@ -242,8 +243,27 @@ The `environments` tool group is optional. Enable it with
 | `reauthorize_environment` | Rotate the authorization code; requires `confirm: true` |
 | `delete_environment` | Delete a user environment; requires `confirm: true` |
 
-The Live and Latest environments are managed by GTM. Create, update, and
-delete operations apply to user environments.
+The Live and Latest environments are managed by GTM. Creation and deletion
+apply to user environments; GTM permits URL and debug updates on other types.
+
+### Destinations and Google tag configurations
+
+These tools are in the optional `destinations` and `gtag` groups.
+
+| Tool | Purpose |
+|---|---|
+| `list_destinations` | List Google tag destinations linked to a container |
+| `get_destination` | Get a destination by its link ID |
+| `link_destination` | Move a destination to a container; requires `confirm: true` |
+| `list_google_tag_configs` | List Google tag configurations in a workspace |
+| `get_google_tag_config` | Get a Google tag configuration |
+| `create_google_tag_config` | Create a Google tag configuration |
+| `update_google_tag_config` | Update a configuration with fingerprint protection |
+| `delete_google_tag_config` | Delete a configuration; requires `confirm: true` |
+
+Container combine, tag-ID move, and destination link operations do not copy or
+enable user permissions. Account permission management remains outside the
+current parity target.
 
 ### Custom templates
 
@@ -469,9 +489,9 @@ hosts.
 `GTM_TOOL_GROUPS` controls schema size for clients that need only part of the
 API. Available groups are `accounts`, `workspaces`, `tags`, `triggers`,
 `variables`, `folders`, `builtins`, `zones`, `templates`, `server`, `guidance`,
-and `environments`. Leaving it unset preserves the established 64-tool surface.
-The newer `environments` group is opt-in. Use `all` to include every current
-and future parity family, or select a subset:
+`environments`, `destinations`, `gtag`, and `container-admin`. Leaving it unset
+preserves the established 64-tool surface. New parity groups are opt-in. Use
+`all` to include every current and future parity family, or select a subset:
 
 ```text
 GTM_TOOL_GROUPS=accounts,workspaces,tags,triggers,variables
@@ -523,7 +543,7 @@ The schema report prints the GTM tool count, serialized `tools/list` size, token
 estimate, and largest definitions. The default GTM tool surface serializes to
 78,734 bytes for 64 tools. A regression test enforces an 80,000-byte ceiling so
 new parity work does not silently consume unlimited model context. The `all`
-group exposes 70 GTM tools, including environments.
+group exposes 80 GTM tools and serializes to 99,593 bytes.
 
 Pull requests run `govulncheck`, `gosec`, Gitleaks, Trivy, `staticcheck`, and
 CodeQL. Request-level GTM tests use local fake Google endpoints. Mutating live
@@ -534,7 +554,7 @@ authentication internals, token persistence, and security invariants.
 
 ## Current limitations
 
-- Official GTM v2 API parity is 70/106, with a target of 101/106.
+- Official GTM v2 API parity is 80/106, with a target of 101/106.
 - The five account user-permission methods are outside the current product
   scope.
 - The server supports Streamable HTTP only. Stdio transport is planned but is

--- a/gtm/container_admin.go
+++ b/gtm/container_admin.go
@@ -1,0 +1,32 @@
+package gtm
+
+import "context"
+
+func (c *Client) CombineContainers(ctx context.Context, accountID, containerID, sourceContainerID, settingSource string) (*Container, error) {
+	result, err := c.Service.Accounts.Containers.Combine(BuildContainerPath(accountID, containerID)).
+		ContainerId(sourceContainerID).
+		SettingSource(settingSource).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	container := toContainer(result)
+	return &container, nil
+}
+
+func (c *Client) MoveTagID(ctx context.Context, accountID, containerID, tagID, tagName string, copySettings bool) (*Container, error) {
+	result, err := c.Service.Accounts.Containers.MoveTagId(BuildContainerPath(accountID, containerID)).
+		TagId(tagID).
+		TagName(tagName).
+		CopySettings(copySettings).
+		CopyTermsOfService(true).
+		CopyUsers(false).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	container := toContainer(result)
+	return &container, nil
+}

--- a/gtm/container_admin_parity_test.go
+++ b/gtm/container_admin_parity_test.go
@@ -1,0 +1,248 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestDestinationsUseOfficialRoutes(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/destinations" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"destination":[{"destinationId":"G-ABC","destinationLinkId":"4","name":"Web","fingerprint":"fp"}]}`)
+		})
+		got, err := client.ListDestinations(context.Background(), "1", "2")
+		if err != nil || len(got) != 1 || got[0].DestinationID != "G-ABC" || got[0].DestinationLinkID != "4" {
+			t.Fatalf("destinations=%+v err=%v", got, err)
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/destinations/4" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"destinationId":"G-ABC","destinationLinkId":"4","name":"Web"}`)
+		})
+		got, err := client.GetDestination(context.Background(), "1", "2", "4")
+		if err != nil || got.Name != "Web" {
+			t.Fatalf("destination=%+v err=%v", got, err)
+		}
+	})
+
+	t.Run("link", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/destinations:link" || r.URL.Query().Get("destinationId") != "G-ABC" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			if r.URL.Query().Has("allowUserPermissionFeatureUpdate") {
+				t.Errorf("permission feature update was unexpectedly enabled: %s", r.URL.RawQuery)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"destinationId":"G-ABC","destinationLinkId":"4"}`)
+		})
+		got, err := client.LinkDestination(context.Background(), "1", "2", "G-ABC")
+		if err != nil || got.DestinationLinkID != "4" {
+			t.Fatalf("destination=%+v err=%v", got, err)
+		}
+	})
+}
+
+func TestContainerAdminOperationsUseSafeOfficialParameters(t *testing.T) {
+	t.Run("combine", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2:combine" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			if r.URL.Query().Get("containerId") != "3" || r.URL.Query().Get("settingSource") != "current" || r.URL.Query().Has("allowUserPermissionFeatureUpdate") {
+				t.Errorf("unexpected query: %s", r.URL.RawQuery)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"containerId":"2","name":"Combined","publicId":"GTM-ABC"}`)
+		})
+		got, err := client.CombineContainers(context.Background(), "1", "2", "3", "current")
+		if err != nil || got.ContainerID != "2" || got.Name != "Combined" {
+			t.Fatalf("container=%+v err=%v", got, err)
+		}
+	})
+
+	t.Run("move tag ID", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2:move_tag_id" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			query := r.URL.Query()
+			if query.Get("tagId") != "G-ABC" || query.Get("tagName") != "New container" || query.Get("copySettings") != "true" || query.Get("copyTermsOfService") != "true" || query.Get("copyUsers") != "false" {
+				t.Errorf("unexpected query: %s", r.URL.RawQuery)
+			}
+			if query.Has("allowUserPermissionFeatureUpdate") {
+				t.Errorf("permission feature update was unexpectedly enabled: %s", r.URL.RawQuery)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"containerId":"3","name":"New container","publicId":"GTM-NEW"}`)
+		})
+		got, err := client.MoveTagID(context.Background(), "1", "2", "G-ABC", "New container", true)
+		if err != nil || got.ContainerID != "3" || got.PublicID != "GTM-NEW" {
+			t.Fatalf("container=%+v err=%v", got, err)
+		}
+	})
+}
+
+func TestGoogleTagConfigCRUDUsesOfficialRoutes(t *testing.T) {
+	t.Run("list paginates", func(t *testing.T) {
+		calls := 0
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/gtag_config" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Query().Get("pageToken") == "" {
+				fmt.Fprint(w, `{"gtagConfig":[{"gtagConfigId":"4","type":"googleTag","parameter":[{"type":"template","key":"tagId","value":"G-ABC"}]}],"nextPageToken":"next"}`)
+			} else {
+				fmt.Fprint(w, `{"gtagConfig":[{"gtagConfigId":"5","type":"googleTag"}]}`)
+			}
+		})
+		got, err := client.ListGoogleTagConfigs(context.Background(), "1", "2", "3")
+		if err != nil || calls != 2 || len(got) != 2 || got[0].ConfigID != "4" || got[0].Parameter == nil {
+			t.Fatalf("calls=%d configs=%+v err=%v", calls, got, err)
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/gtag_config/4" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"gtagConfigId":"4","type":"googleTag","fingerprint":"fp"}`)
+		})
+		got, err := client.GetGoogleTagConfig(context.Background(), "1", "2", "3", "4")
+		if err != nil || got.Fingerprint != "fp" {
+			t.Fatalf("config=%+v err=%v", got, err)
+		}
+	})
+
+	t.Run("create", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/gtag_config" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body["type"] != "googleTag" || body["parameter"] == nil {
+				t.Fatalf("unexpected body: %#v", body)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"gtagConfigId":"4","type":"googleTag"}`)
+		})
+		got, err := client.CreateGoogleTagConfig(context.Background(), "1", "2", "3", GoogleTagConfigCreateConfig{
+			Type: "googleTag", Parameter: []Parameter{{Type: "template", Key: "tagId", Value: "G-ABC"}},
+		})
+		if err != nil || got.ConfigID != "4" {
+			t.Fatalf("config=%+v err=%v", got, err)
+		}
+	})
+
+	t.Run("update preserves and clears", func(t *testing.T) {
+		calls := 0
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			if r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/gtag_config/4" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if calls == 1 {
+				fmt.Fprint(w, `{"gtagConfigId":"4","type":"googleTag","parameter":[{"type":"template","key":"tagId","value":"G-ABC"}],"fingerprint":"old"}`)
+				return
+			}
+			if r.Method != http.MethodPut || r.URL.Query().Get("fingerprint") != "old" {
+				t.Errorf("unexpected update: %s %s", r.Method, r.URL)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body["type"] != "googleTag" {
+				t.Errorf("type not preserved: %#v", body)
+			}
+			if parameters, ok := body["parameter"].([]any); !ok || len(parameters) != 0 {
+				t.Errorf("parameters not cleared: %#v", body)
+			}
+			if _, present := body["gtagConfigId"]; present {
+				t.Errorf("immutable ID sent: %#v", body)
+			}
+			fmt.Fprint(w, `{"gtagConfigId":"4","type":"googleTag","fingerprint":"new"}`)
+		})
+		empty := []Parameter{}
+		got, err := client.UpdateGoogleTagConfig(context.Background(), "1", "2", "3", "4", GoogleTagConfigUpdateConfig{Parameter: &empty})
+		if err != nil || calls != 2 || got.Fingerprint != "new" {
+			t.Fatalf("calls=%d config=%+v err=%v", calls, got, err)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/gtag_config/4" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		if err := client.DeleteGoogleTagConfig(context.Background(), "1", "2", "3", "4"); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestContainerAdminConfirmationGuardsRunBeforeAuth(t *testing.T) {
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	registerLinkDestination(server)
+	registerCombineContainers(server)
+	registerMoveTagID(server)
+	registerDeleteGoogleTagConfig(server)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{"link_destination", map[string]any{"accountId": "1", "containerId": "2", "destinationId": "G-ABC", "confirm": false}},
+		{"combine_containers", map[string]any{"accountId": "1", "containerId": "2", "sourceContainerId": "3", "settingSource": "current", "confirm": false}},
+		{"move_tag_id", map[string]any{"accountId": "1", "containerId": "2", "tagId": "G-ABC", "tagName": "new", "acceptTerms": true, "confirm": false}},
+		{"delete_google_tag_config", map[string]any{"accountId": "1", "containerId": "2", "workspaceId": "3", "gtagConfigId": "4", "confirm": false}},
+	}
+	for _, tc := range cases {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{Name: tc.name, Arguments: tc.args})
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		encoded, _ := json.Marshal(result)
+		if strings.Contains(string(encoded), "not authenticated") {
+			t.Fatalf("%s reached authentication before confirmation: %s", tc.name, encoded)
+		}
+	}
+}

--- a/gtm/destinations.go
+++ b/gtm/destinations.go
@@ -1,0 +1,66 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+type Destination struct {
+	AccountID         string `json:"accountId"`
+	ContainerID       string `json:"containerId"`
+	DestinationID     string `json:"destinationId"`
+	DestinationLinkID string `json:"destinationLinkId,omitempty"`
+	Name              string `json:"name"`
+	Fingerprint       string `json:"fingerprint,omitempty"`
+	Path              string `json:"path"`
+	TagManagerURL     string `json:"tagManagerUrl,omitempty"`
+}
+
+func (c *Client) ListDestinations(ctx context.Context, accountID, containerID string) ([]Destination, error) {
+	response, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListDestinationsResponse, error) {
+		return c.Service.Accounts.Containers.Destinations.List(BuildContainerPath(accountID, containerID)).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := make([]Destination, 0, len(response.Destination))
+	for _, destination := range response.Destination {
+		result = append(result, toDestination(destination))
+	}
+	return result, nil
+}
+
+func (c *Client) GetDestination(ctx context.Context, accountID, containerID, destinationLinkID string) (*Destination, error) {
+	destination, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Destination, error) {
+		return c.Service.Accounts.Containers.Destinations.Get(BuildDestinationPath(accountID, containerID, destinationLinkID)).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toDestination(destination)
+	return &result, nil
+}
+
+func (c *Client) LinkDestination(ctx context.Context, accountID, containerID, destinationID string) (*Destination, error) {
+	destination, err := c.Service.Accounts.Containers.Destinations.Link(BuildContainerPath(accountID, containerID)).DestinationId(destinationID).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toDestination(destination)
+	return &result, nil
+}
+
+func BuildDestinationPath(accountID, containerID, destinationLinkID string) string {
+	return fmt.Sprintf("%s/destinations/%s", BuildContainerPath(accountID, containerID), destinationLinkID)
+}
+
+func toDestination(destination *tagmanager.Destination) Destination {
+	return Destination{
+		AccountID: destination.AccountId, ContainerID: destination.ContainerId,
+		DestinationID: destination.DestinationId, DestinationLinkID: destination.DestinationLinkId,
+		Name: destination.Name, Fingerprint: destination.Fingerprint, Path: destination.Path,
+		TagManagerURL: destination.TagManagerUrl,
+	}
+}

--- a/gtm/gtag_configs.go
+++ b/gtm/gtag_configs.go
@@ -1,0 +1,116 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+type GoogleTagConfig struct {
+	AccountID   string `json:"accountId"`
+	ContainerID string `json:"containerId"`
+	WorkspaceID string `json:"workspaceId"`
+	ConfigID    string `json:"gtagConfigId"`
+	Type        string `json:"type"`
+	// Use any because GTM parameters recursively contain list and map parameters.
+	Parameter     any    `json:"parameter,omitempty"`
+	Fingerprint   string `json:"fingerprint"`
+	Path          string `json:"path"`
+	TagManagerURL string `json:"tagManagerUrl,omitempty"`
+}
+
+type GoogleTagConfigCreateConfig struct {
+	Type      string
+	Parameter []Parameter
+}
+
+type GoogleTagConfigUpdateConfig struct {
+	Type      *string
+	Parameter *[]Parameter
+}
+
+func (c *Client) ListGoogleTagConfigs(ctx context.Context, accountID, containerID, workspaceID string) ([]GoogleTagConfig, error) {
+	parent := BuildWorkspacePath(accountID, containerID, workspaceID)
+	result := make([]GoogleTagConfig, 0)
+	pageToken := ""
+	for {
+		response, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListGtagConfigResponse, error) {
+			return c.Service.Accounts.Containers.Workspaces.GtagConfig.List(parent).PageToken(pageToken).Context(ctx).Do()
+		})
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		for _, config := range response.GtagConfig {
+			result = append(result, toGoogleTagConfig(config))
+		}
+		if response.NextPageToken == "" {
+			return result, nil
+		}
+		pageToken = response.NextPageToken
+	}
+}
+
+func (c *Client) GetGoogleTagConfig(ctx context.Context, accountID, containerID, workspaceID, configID string) (*GoogleTagConfig, error) {
+	config, err := retryWithBackoff(ctx, 3, func() (*tagmanager.GtagConfig, error) {
+		return c.Service.Accounts.Containers.Workspaces.GtagConfig.Get(BuildGoogleTagConfigPath(accountID, containerID, workspaceID, configID)).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toGoogleTagConfig(config)
+	return &result, nil
+}
+
+func (c *Client) CreateGoogleTagConfig(ctx context.Context, accountID, containerID, workspaceID string, input GoogleTagConfigCreateConfig) (*GoogleTagConfig, error) {
+	body := &tagmanager.GtagConfig{Type: input.Type, Parameter: toAPIParams(input.Parameter)}
+	config, err := c.Service.Accounts.Containers.Workspaces.GtagConfig.Create(BuildWorkspacePath(accountID, containerID, workspaceID), body).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toGoogleTagConfig(config)
+	return &result, nil
+}
+
+func (c *Client) UpdateGoogleTagConfig(ctx context.Context, accountID, containerID, workspaceID, configID string, input GoogleTagConfigUpdateConfig) (*GoogleTagConfig, error) {
+	path := BuildGoogleTagConfigPath(accountID, containerID, workspaceID, configID)
+	current, err := retryWithBackoff(ctx, 3, func() (*tagmanager.GtagConfig, error) {
+		return c.Service.Accounts.Containers.Workspaces.GtagConfig.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	body := &tagmanager.GtagConfig{Type: current.Type, Parameter: current.Parameter}
+	if input.Type != nil {
+		body.Type = *input.Type
+	}
+	if input.Parameter != nil {
+		body.Parameter = toAPIParams(*input.Parameter)
+		if len(*input.Parameter) == 0 {
+			body.Parameter = []*tagmanager.Parameter{}
+			body.ForceSendFields = append(body.ForceSendFields, "Parameter")
+		}
+	}
+	config, err := c.Service.Accounts.Containers.Workspaces.GtagConfig.Update(path, body).Fingerprint(current.Fingerprint).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toGoogleTagConfig(config)
+	return &result, nil
+}
+
+func (c *Client) DeleteGoogleTagConfig(ctx context.Context, accountID, containerID, workspaceID, configID string) error {
+	return mapGoogleError(c.Service.Accounts.Containers.Workspaces.GtagConfig.Delete(BuildGoogleTagConfigPath(accountID, containerID, workspaceID, configID)).Context(ctx).Do())
+}
+
+func BuildGoogleTagConfigPath(accountID, containerID, workspaceID, configID string) string {
+	return fmt.Sprintf("%s/gtag_config/%s", BuildWorkspacePath(accountID, containerID, workspaceID), configID)
+}
+
+func toGoogleTagConfig(config *tagmanager.GtagConfig) GoogleTagConfig {
+	return GoogleTagConfig{
+		AccountID: config.AccountId, ContainerID: config.ContainerId, WorkspaceID: config.WorkspaceId,
+		ConfigID: config.GtagConfigId, Type: config.Type, Parameter: config.Parameter,
+		Fingerprint: config.Fingerprint, Path: config.Path, TagManagerURL: config.TagManagerUrl,
+	}
+}

--- a/gtm/tool_container_admin.go
+++ b/gtm/tool_container_admin.go
@@ -1,0 +1,81 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ContainerAdminOutput struct {
+	Success   bool      `json:"success"`
+	Container Container `json:"container"`
+	Message   string    `json:"message"`
+}
+
+type CombineContainersInput struct {
+	AccountID         string `json:"accountId" jsonschema:"description:The GTM account ID shared by both containers"`
+	ContainerID       string `json:"containerId" jsonschema:"description:The target container ID that remains after the combine"`
+	SourceContainerID string `json:"sourceContainerId" jsonschema:"description:The container ID merged into the target"`
+	SettingSource     string `json:"settingSource" jsonschema:"description:Which container settings to retain: current or other"`
+	Confirm           bool   `json:"confirm" jsonschema:"description:Must be true to confirm the irreversible container combine"`
+}
+
+type MoveTagIDInput struct {
+	AccountID    string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID  string `json:"containerId" jsonschema:"description:The container currently holding the tag ID"`
+	TagID        string `json:"tagId" jsonschema:"description:The tag ID to remove from the current container"`
+	TagName      string `json:"tagName" jsonschema:"description:The name for the newly created container"`
+	CopySettings bool   `json:"copySettings,omitempty" jsonschema:"description:Copy tag settings to the newly created container"`
+	AcceptTerms  bool   `json:"acceptTerms" jsonschema:"description:Must be true to accept the terms copied to the new container"`
+	Confirm      bool   `json:"confirm" jsonschema:"description:Must be true to confirm moving the tag ID"`
+}
+
+func registerCombineContainers(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "combine_containers", Description: "Merge another container into this target container. Requires confirm: true and never changes the user-permissions feature."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input CombineContainersInput) (*mcp.CallToolResult, ContainerAdminOutput, error) {
+			if !input.Confirm {
+				return nil, ContainerAdminOutput{Message: "Container combine requires confirm: true"}, nil
+			}
+			if strings.TrimSpace(input.SourceContainerID) == "" || input.SourceContainerID == input.ContainerID {
+				return nil, ContainerAdminOutput{}, fmt.Errorf("source container ID must identify a different container")
+			}
+			if input.SettingSource != "current" && input.SettingSource != "other" {
+				return nil, ContainerAdminOutput{}, fmt.Errorf("settingSource must be current or other")
+			}
+			cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+			if err != nil {
+				return nil, ContainerAdminOutput{}, err
+			}
+			container, err := cc.Client.CombineContainers(ctx, cc.AccountID, cc.ContainerID, input.SourceContainerID, input.SettingSource)
+			if err != nil {
+				return nil, ContainerAdminOutput{}, err
+			}
+			return nil, ContainerAdminOutput{Success: true, Container: *container, Message: "Containers combined successfully"}, nil
+		})
+}
+
+func registerMoveTagID(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "move_tag_id", Description: "Move a tag ID out of a container into a new container. Requires confirm: true and acceptTerms: true; users are not copied."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input MoveTagIDInput) (*mcp.CallToolResult, ContainerAdminOutput, error) {
+			if !input.Confirm {
+				return nil, ContainerAdminOutput{Message: "Moving a tag ID requires confirm: true"}, nil
+			}
+			if !input.AcceptTerms {
+				return nil, ContainerAdminOutput{}, fmt.Errorf("acceptTerms must be true")
+			}
+			if strings.TrimSpace(input.TagID) == "" || strings.TrimSpace(input.TagName) == "" {
+				return nil, ContainerAdminOutput{}, fmt.Errorf("tagId and tagName are required")
+			}
+			cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+			if err != nil {
+				return nil, ContainerAdminOutput{}, err
+			}
+			container, err := cc.Client.MoveTagID(ctx, cc.AccountID, cc.ContainerID, input.TagID, input.TagName, input.CopySettings)
+			if err != nil {
+				return nil, ContainerAdminOutput{}, err
+			}
+			return nil, ContainerAdminOutput{Success: true, Container: *container, Message: "Tag ID moved successfully"}, nil
+		})
+}

--- a/gtm/tool_destinations.go
+++ b/gtm/tool_destinations.go
@@ -1,0 +1,81 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DestinationInput struct {
+	AccountID         string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID       string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	DestinationLinkID string `json:"destinationLinkId" jsonschema:"description:The container-specific destination link ID returned by list_destinations"`
+}
+
+type ListDestinationsOutput struct {
+	Destinations []Destination `json:"destinations"`
+}
+
+type DestinationOutput struct {
+	Destination Destination `json:"destination"`
+}
+
+type LinkDestinationInput struct {
+	AccountID     string `json:"accountId" jsonschema:"description:The receiving GTM account ID"`
+	ContainerID   string `json:"containerId" jsonschema:"description:The receiving GTM container ID"`
+	DestinationID string `json:"destinationId" jsonschema:"description:The destination ID to move to this container"`
+	Confirm       bool   `json:"confirm" jsonschema:"description:Must be true because linking moves the destination from its current container"`
+}
+
+func registerListDestinations(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "list_destinations", Description: "List Google tag destinations linked to a GTM container."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input EnvironmentContainerInput) (*mcp.CallToolResult, ListDestinationsOutput, error) {
+			cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+			if err != nil {
+				return nil, ListDestinationsOutput{}, err
+			}
+			destinations, err := cc.Client.ListDestinations(ctx, cc.AccountID, cc.ContainerID)
+			return nil, ListDestinationsOutput{Destinations: destinations}, err
+		})
+}
+
+func registerGetDestination(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "get_destination", Description: "Get a Google tag destination by its container-specific link ID."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input DestinationInput) (*mcp.CallToolResult, DestinationOutput, error) {
+			if strings.TrimSpace(input.DestinationLinkID) == "" {
+				return nil, DestinationOutput{}, fmt.Errorf("destination link ID is required")
+			}
+			cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+			if err != nil {
+				return nil, DestinationOutput{}, err
+			}
+			destination, err := cc.Client.GetDestination(ctx, cc.AccountID, cc.ContainerID, input.DestinationLinkID)
+			if err != nil {
+				return nil, DestinationOutput{}, err
+			}
+			return nil, DestinationOutput{Destination: *destination}, nil
+		})
+}
+
+func registerLinkDestination(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "link_destination", Description: "Move a Google tag destination to this container. Requires confirm: true; user permissions are not copied or changed."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input LinkDestinationInput) (*mcp.CallToolResult, DestinationOutput, error) {
+			if !input.Confirm {
+				return nil, DestinationOutput{}, fmt.Errorf("destination linking requires confirm: true")
+			}
+			if strings.TrimSpace(input.DestinationID) == "" {
+				return nil, DestinationOutput{}, fmt.Errorf("destination ID is required")
+			}
+			cc, err := resolveContainer(ctx, input.AccountID, input.ContainerID)
+			if err != nil {
+				return nil, DestinationOutput{}, err
+			}
+			destination, err := cc.Client.LinkDestination(ctx, cc.AccountID, cc.ContainerID, input.DestinationID)
+			if err != nil {
+				return nil, DestinationOutput{}, err
+			}
+			return nil, DestinationOutput{Destination: *destination}, nil
+		})
+}

--- a/gtm/tool_groups_test.go
+++ b/gtm/tool_groups_test.go
@@ -77,8 +77,8 @@ func TestDefaultPreservesSurfaceAndAllIncludesOptionalGroups(t *testing.T) {
 	if got := registeredToolCount(t, defaults); got != 64 {
 		t.Fatalf("default=%d, want 64", got)
 	}
-	if got := registeredToolCount(t, all); got != 70 {
-		t.Fatalf("all=%d, want 70", got)
+	if got := registeredToolCount(t, all); got != 80 {
+		t.Fatalf("all=%d, want 80", got)
 	}
 }
 

--- a/gtm/tool_gtag_configs.go
+++ b/gtm/tool_gtag_configs.go
@@ -1,0 +1,155 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GoogleTagConfigInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	ConfigID    string `json:"gtagConfigId" jsonschema:"description:The Google tag config ID"`
+}
+
+type ListGoogleTagConfigsOutput struct {
+	Configs []GoogleTagConfig `json:"gtagConfigs"`
+}
+
+type GoogleTagConfigOutput struct {
+	Success bool            `json:"success,omitempty"`
+	Config  GoogleTagConfig `json:"gtagConfig"`
+	Message string          `json:"message,omitempty"`
+}
+
+type CreateGoogleTagConfigInput struct {
+	AccountID      string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID    string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID    string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	Type           string `json:"type" jsonschema:"description:The Google tag configuration type"`
+	ParametersJSON string `json:"parametersJson,omitempty" jsonschema:"description:Google tag parameters as a JSON array; each parameter has type, key, value, list, or map fields"`
+}
+
+type UpdateGoogleTagConfigInput struct {
+	GoogleTagConfigInput
+	Type           *string `json:"type,omitempty" jsonschema:"description:New config type; omit to preserve"`
+	ParametersJSON *string `json:"parametersJson,omitempty" jsonschema:"description:New parameters as a JSON array; omit to preserve or pass [] to clear"`
+}
+
+type DeleteGoogleTagConfigInput struct {
+	GoogleTagConfigInput
+	Confirm bool `json:"confirm" jsonschema:"description:Must be true to confirm deletion"`
+}
+
+type DeleteGoogleTagConfigOutput struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+func registerListGoogleTagConfigs(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "list_google_tag_configs", Description: "List Google tag configurations in a workspace across every result page."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input WorkspaceInput) (*mcp.CallToolResult, ListGoogleTagConfigsOutput, error) {
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, ListGoogleTagConfigsOutput{}, err
+			}
+			configs, err := wc.Client.ListGoogleTagConfigs(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID)
+			return nil, ListGoogleTagConfigsOutput{Configs: configs}, err
+		})
+}
+
+func registerGetGoogleTagConfig(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "get_google_tag_config", Description: "Get a Google tag configuration by ID."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input GoogleTagConfigInput) (*mcp.CallToolResult, GoogleTagConfigOutput, error) {
+			wc, err := resolveGoogleTagConfig(ctx, input)
+			if err != nil {
+				return nil, GoogleTagConfigOutput{}, err
+			}
+			config, err := wc.Client.GetGoogleTagConfig(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.ConfigID)
+			if err != nil {
+				return nil, GoogleTagConfigOutput{}, err
+			}
+			return nil, GoogleTagConfigOutput{Config: *config}, nil
+		})
+}
+
+func registerCreateGoogleTagConfig(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "create_google_tag_config", Description: "Create a Google tag configuration in a workspace."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input CreateGoogleTagConfigInput) (*mcp.CallToolResult, GoogleTagConfigOutput, error) {
+			if strings.TrimSpace(input.Type) == "" {
+				return nil, GoogleTagConfigOutput{}, fmt.Errorf("type is required")
+			}
+			var parameters []Parameter
+			if strings.TrimSpace(input.ParametersJSON) != "" {
+				if err := json.Unmarshal([]byte(input.ParametersJSON), &parameters); err != nil {
+					return nil, GoogleTagConfigOutput{}, fmt.Errorf("invalid parametersJson: %w", err)
+				}
+			}
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, GoogleTagConfigOutput{}, err
+			}
+			config, err := wc.Client.CreateGoogleTagConfig(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, GoogleTagConfigCreateConfig{Type: input.Type, Parameter: parameters})
+			if err != nil {
+				return nil, GoogleTagConfigOutput{}, err
+			}
+			return nil, GoogleTagConfigOutput{Success: true, Config: *config, Message: "Google tag config created successfully"}, nil
+		})
+}
+
+func registerUpdateGoogleTagConfig(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "update_google_tag_config", Description: "Update selected Google tag configuration fields while preserving omitted values and checking its fingerprint."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateGoogleTagConfigInput) (*mcp.CallToolResult, GoogleTagConfigOutput, error) {
+			if input.Type == nil && input.ParametersJSON == nil {
+				return nil, GoogleTagConfigOutput{}, fmt.Errorf("provide type or parameter to update")
+			}
+			if input.Type != nil && strings.TrimSpace(*input.Type) == "" {
+				return nil, GoogleTagConfigOutput{}, fmt.Errorf("type cannot be empty")
+			}
+			var parameters *[]Parameter
+			if input.ParametersJSON != nil {
+				var parsed []Parameter
+				if err := json.Unmarshal([]byte(*input.ParametersJSON), &parsed); err != nil {
+					return nil, GoogleTagConfigOutput{}, fmt.Errorf("invalid parametersJson: %w", err)
+				}
+				parameters = &parsed
+			}
+			wc, err := resolveGoogleTagConfig(ctx, input.GoogleTagConfigInput)
+			if err != nil {
+				return nil, GoogleTagConfigOutput{}, err
+			}
+			config, err := wc.Client.UpdateGoogleTagConfig(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.ConfigID, GoogleTagConfigUpdateConfig{Type: input.Type, Parameter: parameters})
+			if err != nil {
+				return nil, GoogleTagConfigOutput{}, err
+			}
+			return nil, GoogleTagConfigOutput{Success: true, Config: *config, Message: "Google tag config updated successfully"}, nil
+		})
+}
+
+func registerDeleteGoogleTagConfig(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "delete_google_tag_config", Description: "Delete a Google tag configuration. Requires confirm: true."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input DeleteGoogleTagConfigInput) (*mcp.CallToolResult, DeleteGoogleTagConfigOutput, error) {
+			if !input.Confirm {
+				return nil, DeleteGoogleTagConfigOutput{Message: "Google tag config deletion requires confirm: true"}, nil
+			}
+			wc, err := resolveGoogleTagConfig(ctx, input.GoogleTagConfigInput)
+			if err != nil {
+				return nil, DeleteGoogleTagConfigOutput{}, err
+			}
+			if err := wc.Client.DeleteGoogleTagConfig(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.ConfigID); err != nil {
+				return nil, DeleteGoogleTagConfigOutput{}, err
+			}
+			return nil, DeleteGoogleTagConfigOutput{Success: true, Message: "Google tag config deleted successfully"}, nil
+		})
+}
+
+func resolveGoogleTagConfig(ctx context.Context, input GoogleTagConfigInput) (*WorkspaceContext, error) {
+	if strings.TrimSpace(input.ConfigID) == "" {
+		return nil, fmt.Errorf("google tag config ID is required")
+	}
+	return resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+}

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -21,7 +21,7 @@ var defaultToolGroupNames = []string{
 	"folders", "builtins", "zones", "templates", "server", "guidance",
 }
 
-var optionalToolGroupNames = []string{"environments"}
+var optionalToolGroupNames = []string{"environments", "destinations", "gtag", "container-admin"}
 
 // ParseToolGroups validates GTM_TOOL_GROUPS. An empty value preserves the
 // complete pre-grouping tool surface. "all" also enables future families.
@@ -141,6 +141,25 @@ func RegisterToolsForGroups(server *mcp.Server, groups ToolGroups) {
 		registerUpdateEnvironment(server)
 		registerReauthorizeEnvironment(server)
 		registerDeleteEnvironment(server)
+	}
+
+	if groups.enabled("destinations") {
+		registerListDestinations(server)
+		registerGetDestination(server)
+		registerLinkDestination(server)
+	}
+
+	if groups.enabled("gtag") {
+		registerListGoogleTagConfigs(server)
+		registerGetGoogleTagConfig(server)
+		registerCreateGoogleTagConfig(server)
+		registerUpdateGoogleTagConfig(server)
+		registerDeleteGoogleTagConfig(server)
+	}
+
+	if groups.enabled("container-admin") {
+		registerCombineContainers(server)
+		registerMoveTagID(server)
 	}
 
 	if groups.enabled("builtins") {

--- a/llms.txt
+++ b/llms.txt
@@ -52,6 +52,10 @@ Always discover IDs by listing — never guess or hardcode them.
 | `get_zone` | Get a zone and its configuration |
 | `list_environments` | List container environments (optional `environments` group) |
 | `get_environment` | Get an environment and authorization metadata |
+| `list_destinations` | List Google tag destinations linked to a container |
+| `get_destination` | Get a destination by its link ID |
+| `list_google_tag_configs` | List workspace Google tag configurations |
+| `get_google_tag_config` | Get a Google tag configuration |
 | `list_built_in_variables` | List enabled built-in variables |
 | `get_workspace_status` | Check pending changes and merge conflicts |
 
@@ -77,6 +81,12 @@ Always discover IDs by listing — never guess or hardcode them.
 | `update_environment` | Update a user environment with fingerprint protection |
 | `reauthorize_environment` | Rotate an environment authorization code (requires `confirm: true`) |
 | `delete_environment` | Delete a user environment (requires `confirm: true`) |
+| `link_destination` | Move a destination to a container (requires `confirm: true`) |
+| `create_google_tag_config` | Create a Google tag configuration |
+| `update_google_tag_config` | Update a Google tag configuration |
+| `delete_google_tag_config` | Delete a Google tag configuration (requires `confirm: true`) |
+| `combine_containers` | Merge one container into another (requires `confirm: true`) |
+| `move_tag_id` | Move a tag ID to a new container (requires confirmation and terms acceptance) |
 | `update_account` | Rename a GTM account |
 | `enable_built_in_variables` | Enable built-in variable types |
 | `disable_built_in_variables` | Disable built-in variable types (requires `confirm: true`) |


### PR DESCRIPTION
Adds ten official GTM v2 methods across destinations, Google tag configurations, and container administration, raising coverage from 70/106 to 80/106 after #117.

The slice provides destination list/get/link, Google tag configuration CRUD, container combine, and tag-ID move. Updates preserve omitted fields and use fingerprints. Destination moves, config deletion, container combines, and tag-ID moves require explicit confirmation. Container operations leave permission-feature updates disabled, and tag-ID moves explicitly avoid copying users.

This PR is stacked on #117. Once #117 merges, GitHub will show only this commit's changes against `main`.

Validation:

- `go test ./... -count=1`
- `go vet ./...`
- `staticcheck ./...`
- schema report: default remains 64 tools / 78,734 bytes; `all` is 80 tools / 99,593 bytes
