### PR TITLE
feat: complete workspace and folder APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,20 @@ service-account authentication for self-hosted automation.
 |---|---|
 | Version in `server.json` | `1.10.1` |
 | Transport | MCP Streamable HTTP |
-| Runtime tools | 64 GTM tools by default; 80 with `GTM_TOOL_GROUPS=all`, plus 2 utility tools |
+| Runtime tools | 64 GTM tools by default; 89 with `GTM_TOOL_GROUPS=all`, plus 2 utility tools |
 | MCP resources | 8 resource definitions |
 | MCP prompts | 6 prompts |
-| Official GTM API coverage | 80 of 106 methods |
+| Official GTM API coverage | 89 of 106 methods |
 | Planned parity target | 101 of 106 methods |
 | Hosted endpoint | `https://mcp.gtmeditor.com` |
 
-API parity is **not complete**. The project has implemented 80 methods from
-Google's 106-method GTM v2 discovery surface. Another 21 methods are planned.
+API parity is **not complete**. The project has implemented 89 methods from
+Google's 106-method GTM v2 discovery surface. Another 12 methods are planned.
 The five `accounts.user_permissions` methods are intentionally excluded because
 granting and revoking GTM access needs a separate privilege-management design.
 
-The remaining roadmap includes workspace synchronization and conflict
-resolution, folder lifecycle operations, version state changes, and resource
-revert operations.
+The remaining roadmap includes version state changes and resource revert
+operations.
 
 Tool count and API-method count are different. Some tools provide local
 guidance, while some helpers cover more than one Google API call.
@@ -164,9 +163,12 @@ request. Inputs and outputs are structured JSON.
 | `delete_workspace` | Delete a workspace; requires `confirm: true` |
 | `quick_preview_workspace` | Compile an ephemeral preview without saving or publishing |
 | `get_workspace_status` | Show pending changes and merge conflicts |
+| `bulk_update_workspace` | Apply multiple entity changes; requires `confirm: true` |
+| `resolve_workspace_conflict` | Replace a conflict with a resolved entity; requires `confirm: true` |
+| `sync_workspace` | Synchronize with the latest container version; requires `confirm: true` |
 
-Workspace synchronization, bulk update, and conflict resolution remain on the
-parity roadmap.
+Bulk update and conflict resolution accept raw GTM Entity JSON so every entity
+type supported by the official API remains available.
 
 ### Tags
 
@@ -209,13 +211,18 @@ GTM drops `autoEventFilter` for those trigger types.
 | Tool | Purpose |
 |---|---|
 | `list_folders` | List workspace folders |
+| `get_folder` | Get complete folder metadata |
+| `create_folder` | Create a folder |
+| `update_folder` | Update a folder with fingerprint protection |
+| `delete_folder` | Delete a folder; requires `confirm: true` |
 | `get_folder_entities` | List tags, triggers, and variables assigned to a folder |
+| `move_entities_to_folder` | Move tags, triggers, and variables; requires `confirm: true` |
+| `revert_folder` | Discard workspace folder changes; requires `confirm: true` |
 | `list_built_in_variables` | List enabled built-in variables |
 | `enable_built_in_variables` | Enable built-in variable types |
 | `disable_built_in_variables` | Disable built-in variable types; requires `confirm: true` |
 
-Folder create/get/update/delete/move/revert and built-in-variable revert remain
-on the parity roadmap.
+Built-in-variable revert remains on the parity roadmap.
 
 ### Zones
 
@@ -489,9 +496,10 @@ hosts.
 `GTM_TOOL_GROUPS` controls schema size for clients that need only part of the
 API. Available groups are `accounts`, `workspaces`, `tags`, `triggers`,
 `variables`, `folders`, `builtins`, `zones`, `templates`, `server`, `guidance`,
-`environments`, `destinations`, `gtag`, and `container-admin`. Leaving it unset
-preserves the established 64-tool surface. New parity groups are opt-in. Use
-`all` to include every current and future parity family, or select a subset:
+`environments`, `destinations`, `gtag`, `container-admin`, `folder-admin`, and
+`workspace-admin`. Leaving it unset preserves the established 64-tool surface.
+New parity groups are opt-in. Use `all` to include every current and future
+parity family, or select a subset:
 
 ```text
 GTM_TOOL_GROUPS=accounts,workspaces,tags,triggers,variables
@@ -543,7 +551,7 @@ The schema report prints the GTM tool count, serialized `tools/list` size, token
 estimate, and largest definitions. The default GTM tool surface serializes to
 78,734 bytes for 64 tools. A regression test enforces an 80,000-byte ceiling so
 new parity work does not silently consume unlimited model context. The `all`
-group exposes 80 GTM tools and serializes to 99,593 bytes.
+group exposes 89 GTM tools and serializes to 109,447 bytes.
 
 Pull requests run `govulncheck`, `gosec`, Gitleaks, Trivy, `staticcheck`, and
 CodeQL. Request-level GTM tests use local fake Google endpoints. Mutating live
@@ -554,7 +562,7 @@ authentication internals, token persistence, and security invariants.
 
 ## Current limitations
 
-- Official GTM v2 API parity is 80/106, with a target of 101/106.
+- Official GTM v2 API parity is 89/106, with a target of 101/106.
 - The five account user-permission methods are outside the current product
   scope.
 - The server supports Streamable HTTP only. Stdio transport is planned but is

--- a/gtm/folders.go
+++ b/gtm/folders.go
@@ -9,10 +9,15 @@ import (
 
 // Folder is a simplified representation of a GTM folder.
 type Folder struct {
-	FolderID string `json:"folderId"`
-	Name     string `json:"name"`
-	Path     string `json:"path"`
-	Notes    string `json:"notes,omitempty"`
+	AccountID     string `json:"accountId,omitempty"`
+	ContainerID   string `json:"containerId,omitempty"`
+	WorkspaceID   string `json:"workspaceId,omitempty"`
+	FolderID      string `json:"folderId"`
+	Name          string `json:"name"`
+	Path          string `json:"path"`
+	Notes         string `json:"notes,omitempty"`
+	Fingerprint   string `json:"fingerprint,omitempty"`
+	TagManagerURL string `json:"tagManagerUrl,omitempty"`
 }
 
 // FolderEntities contains the entities within a folder.
@@ -26,14 +31,106 @@ type FolderEntities struct {
 func (c *Client) ListFolders(ctx context.Context, accountID, containerID, workspaceID string) ([]Folder, error) {
 	parent := fmt.Sprintf("accounts/%s/containers/%s/workspaces/%s", accountID, containerID, workspaceID)
 
-	resp, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListFoldersResponse, error) {
-		return c.Service.Accounts.Containers.Workspaces.Folders.List(parent).Context(ctx).Do()
+	result := make([]Folder, 0)
+	pageToken := ""
+	for {
+		resp, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ListFoldersResponse, error) {
+			return c.Service.Accounts.Containers.Workspaces.Folders.List(parent).PageToken(pageToken).Context(ctx).Do()
+		})
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result = append(result, toFolders(resp.Folder)...)
+		if resp.NextPageToken == "" {
+			return result, nil
+		}
+		pageToken = resp.NextPageToken
+	}
+}
+
+func (c *Client) GetFolder(ctx context.Context, accountID, containerID, workspaceID, folderID string) (*Folder, error) {
+	folder, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Folder, error) {
+		return c.Service.Accounts.Containers.Workspaces.Folders.Get(BuildFolderPath(accountID, containerID, workspaceID, folderID)).Context(ctx).Do()
 	})
 	if err != nil {
 		return nil, mapGoogleError(err)
 	}
+	result := toFolder(folder)
+	return &result, nil
+}
 
-	return toFolders(resp.Folder), nil
+func (c *Client) CreateFolder(ctx context.Context, accountID, containerID, workspaceID, name, notes string) (*Folder, error) {
+	folder, err := c.Service.Accounts.Containers.Workspaces.Folders.Create(BuildWorkspacePath(accountID, containerID, workspaceID), &tagmanager.Folder{Name: name, Notes: notes}).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toFolder(folder)
+	return &result, nil
+}
+
+func (c *Client) UpdateFolder(ctx context.Context, accountID, containerID, workspaceID, folderID string, name, notes *string) (*Folder, error) {
+	path := BuildFolderPath(accountID, containerID, workspaceID, folderID)
+	current, err := retryWithBackoff(ctx, 3, func() (*tagmanager.Folder, error) {
+		return c.Service.Accounts.Containers.Workspaces.Folders.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	body := &tagmanager.Folder{Name: current.Name, Notes: current.Notes}
+	if name != nil {
+		body.Name = *name
+	}
+	if notes != nil {
+		body.Notes = *notes
+		if *notes == "" {
+			body.ForceSendFields = append(body.ForceSendFields, "Notes")
+		}
+	}
+	folder, err := c.Service.Accounts.Containers.Workspaces.Folders.Update(path, body).Fingerprint(current.Fingerprint).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toFolder(folder)
+	return &result, nil
+}
+
+func (c *Client) DeleteFolder(ctx context.Context, accountID, containerID, workspaceID, folderID string) error {
+	return mapGoogleError(c.Service.Accounts.Containers.Workspaces.Folders.Delete(BuildFolderPath(accountID, containerID, workspaceID, folderID)).Context(ctx).Do())
+}
+
+func (c *Client) MoveEntitiesToFolder(ctx context.Context, accountID, containerID, workspaceID, folderID string, tagIDs, triggerIDs, variableIDs []string) error {
+	call := c.Service.Accounts.Containers.Workspaces.Folders.MoveEntitiesToFolder(BuildFolderPath(accountID, containerID, workspaceID, folderID), &tagmanager.Folder{})
+	if len(tagIDs) > 0 {
+		call.TagId(tagIDs...)
+	}
+	if len(triggerIDs) > 0 {
+		call.TriggerId(triggerIDs...)
+	}
+	if len(variableIDs) > 0 {
+		call.VariableId(variableIDs...)
+	}
+	return mapGoogleError(call.Context(ctx).Do())
+}
+
+func (c *Client) RevertFolder(ctx context.Context, accountID, containerID, workspaceID, folderID string) (*Folder, error) {
+	path := BuildFolderPath(accountID, containerID, workspaceID, folderID)
+	current, err := c.Service.Accounts.Containers.Workspaces.Folders.Get(path).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	response, err := c.Service.Accounts.Containers.Workspaces.Folders.Revert(path).Fingerprint(current.Fingerprint).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	if response.Folder == nil {
+		return nil, nil
+	}
+	result := toFolder(response.Folder)
+	return &result, nil
+}
+
+func BuildFolderPath(accountID, containerID, workspaceID, folderID string) string {
+	return fmt.Sprintf("%s/folders/%s", BuildWorkspacePath(accountID, containerID, workspaceID), folderID)
 }
 
 // GetFolderEntities returns the entities (tags, triggers, variables) in a folder.
@@ -41,37 +138,43 @@ func (c *Client) GetFolderEntities(ctx context.Context, accountID, containerID, 
 	path := fmt.Sprintf("accounts/%s/containers/%s/workspaces/%s/folders/%s",
 		accountID, containerID, workspaceID, folderID)
 
-	resp, err := retryWithBackoff(ctx, 3, func() (*tagmanager.FolderEntities, error) {
-		return c.Service.Accounts.Containers.Workspaces.Folders.Entities(path).Context(ctx).Do()
-	})
-	if err != nil {
-		return nil, mapGoogleError(err)
-	}
-
 	entities := &FolderEntities{}
-
-	for _, t := range resp.Tag {
-		entities.Tags = append(entities.Tags, t.Name)
+	pageToken := ""
+	for {
+		resp, err := retryWithBackoff(ctx, 3, func() (*tagmanager.FolderEntities, error) {
+			return c.Service.Accounts.Containers.Workspaces.Folders.Entities(path).PageToken(pageToken).Context(ctx).Do()
+		})
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		for _, tag := range resp.Tag {
+			entities.Tags = append(entities.Tags, tag.Name)
+		}
+		for _, trigger := range resp.Trigger {
+			entities.Triggers = append(entities.Triggers, trigger.Name)
+		}
+		for _, variable := range resp.Variable {
+			entities.Variables = append(entities.Variables, variable.Name)
+		}
+		if resp.NextPageToken == "" {
+			return entities, nil
+		}
+		pageToken = resp.NextPageToken
 	}
-	for _, t := range resp.Trigger {
-		entities.Triggers = append(entities.Triggers, t.Name)
-	}
-	for _, v := range resp.Variable {
-		entities.Variables = append(entities.Variables, v.Name)
-	}
-
-	return entities, nil
 }
 
 func toFolders(folders []*tagmanager.Folder) []Folder {
 	result := make([]Folder, 0, len(folders))
 	for _, f := range folders {
-		result = append(result, Folder{
-			FolderID: f.FolderId,
-			Name:     f.Name,
-			Path:     f.Path,
-			Notes:    f.Notes,
-		})
+		result = append(result, toFolder(f))
 	}
 	return result
+}
+
+func toFolder(folder *tagmanager.Folder) Folder {
+	return Folder{
+		AccountID: folder.AccountId, ContainerID: folder.ContainerId, WorkspaceID: folder.WorkspaceId,
+		FolderID: folder.FolderId, Name: folder.Name, Path: folder.Path, Notes: folder.Notes,
+		Fingerprint: folder.Fingerprint, TagManagerURL: folder.TagManagerUrl,
+	}
 }

--- a/gtm/tool_folders.go
+++ b/gtm/tool_folders.go
@@ -2,6 +2,8 @@ package gtm
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -29,6 +31,51 @@ type GetFolderEntitiesInput struct {
 // GetFolderEntitiesOutput is the output for get_folder_entities tool.
 type GetFolderEntitiesOutput struct {
 	Entities FolderEntities `json:"entities"`
+}
+
+type FolderInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	FolderID    string `json:"folderId" jsonschema:"description:The folder ID"`
+}
+
+type FolderOutput struct {
+	Success bool    `json:"success,omitempty"`
+	Folder  *Folder `json:"folder,omitempty"`
+	Message string  `json:"message,omitempty"`
+}
+
+type CreateFolderInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	WorkspaceID string `json:"workspaceId" jsonschema:"description:The GTM workspace ID"`
+	Name        string `json:"name" jsonschema:"description:Folder display name"`
+	Notes       string `json:"notes,omitempty" jsonschema:"description:Optional folder notes"`
+}
+
+type UpdateFolderInput struct {
+	FolderInput
+	Name  *string `json:"name,omitempty" jsonschema:"description:New name; omit to preserve"`
+	Notes *string `json:"notes,omitempty" jsonschema:"description:New notes; omit to preserve or pass empty to clear"`
+}
+
+type ConfirmFolderInput struct {
+	FolderInput
+	Confirm bool `json:"confirm" jsonschema:"description:Must be true to confirm the operation"`
+}
+
+type MoveEntitiesToFolderInput struct {
+	FolderInput
+	TagIDs      []string `json:"tagIds,omitempty" jsonschema:"description:Tag IDs to move"`
+	TriggerIDs  []string `json:"triggerIds,omitempty" jsonschema:"description:Trigger IDs to move"`
+	VariableIDs []string `json:"variableIds,omitempty" jsonschema:"description:Variable IDs to move"`
+	Confirm     bool     `json:"confirm" jsonschema:"description:Must be true to confirm moving the entities"`
+}
+
+type FolderActionOutput struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
 }
 
 func registerListFolders(server *mcp.Server) {
@@ -71,4 +118,104 @@ func registerGetFolderEntities(server *mcp.Server) {
 		Name:        "get_folder_entities",
 		Description: "Get the tags, triggers, and variables inside a specific folder.",
 	}, handler)
+}
+
+func registerGetFolder(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "get_folder", Description: "Get a GTM folder by ID."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input FolderInput) (*mcp.CallToolResult, FolderOutput, error) {
+			wc, err := resolveFolder(ctx, input)
+			if err != nil {
+				return nil, FolderOutput{}, err
+			}
+			folder, err := wc.Client.GetFolder(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.FolderID)
+			return nil, FolderOutput{Folder: folder}, err
+		})
+}
+
+func registerCreateFolder(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "create_folder", Description: "Create a folder in a GTM workspace."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input CreateFolderInput) (*mcp.CallToolResult, FolderOutput, error) {
+			if strings.TrimSpace(input.Name) == "" {
+				return nil, FolderOutput{}, fmt.Errorf("name is required")
+			}
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, FolderOutput{}, err
+			}
+			folder, err := wc.Client.CreateFolder(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.Name, input.Notes)
+			return nil, FolderOutput{Success: err == nil, Folder: folder, Message: "Folder created successfully"}, err
+		})
+}
+
+func registerUpdateFolder(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "update_folder", Description: "Update selected folder fields while preserving omitted values and checking its fingerprint."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateFolderInput) (*mcp.CallToolResult, FolderOutput, error) {
+			if input.Name == nil && input.Notes == nil {
+				return nil, FolderOutput{}, fmt.Errorf("provide name or notes to update")
+			}
+			if input.Name != nil && strings.TrimSpace(*input.Name) == "" {
+				return nil, FolderOutput{}, fmt.Errorf("name cannot be empty")
+			}
+			wc, err := resolveFolder(ctx, input.FolderInput)
+			if err != nil {
+				return nil, FolderOutput{}, err
+			}
+			folder, err := wc.Client.UpdateFolder(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.FolderID, input.Name, input.Notes)
+			return nil, FolderOutput{Success: err == nil, Folder: folder, Message: "Folder updated successfully"}, err
+		})
+}
+
+func registerDeleteFolder(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "delete_folder", Description: "Delete a GTM folder. Requires confirm: true."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input ConfirmFolderInput) (*mcp.CallToolResult, FolderActionOutput, error) {
+			if !input.Confirm {
+				return nil, FolderActionOutput{Message: "Folder deletion requires confirm: true"}, nil
+			}
+			wc, err := resolveFolder(ctx, input.FolderInput)
+			if err != nil {
+				return nil, FolderActionOutput{}, err
+			}
+			err = wc.Client.DeleteFolder(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.FolderID)
+			return nil, FolderActionOutput{Success: err == nil, Message: "Folder deleted successfully"}, err
+		})
+}
+
+func registerMoveEntitiesToFolder(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "move_entities_to_folder", Description: "Move tags, triggers, and variables into a folder. Requires confirm: true."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input MoveEntitiesToFolderInput) (*mcp.CallToolResult, FolderActionOutput, error) {
+			if !input.Confirm {
+				return nil, FolderActionOutput{Message: "Moving entities requires confirm: true"}, nil
+			}
+			if len(input.TagIDs)+len(input.TriggerIDs)+len(input.VariableIDs) == 0 {
+				return nil, FolderActionOutput{}, fmt.Errorf("provide at least one tag, trigger, or variable ID")
+			}
+			wc, err := resolveFolder(ctx, input.FolderInput)
+			if err != nil {
+				return nil, FolderActionOutput{}, err
+			}
+			err = wc.Client.MoveEntitiesToFolder(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.FolderID, input.TagIDs, input.TriggerIDs, input.VariableIDs)
+			return nil, FolderActionOutput{Success: err == nil, Message: "Entities moved successfully"}, err
+		})
+}
+
+func registerRevertFolder(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "revert_folder", Description: "Discard workspace changes to a folder and restore its latest-version state. Requires confirm: true."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input ConfirmFolderInput) (*mcp.CallToolResult, FolderOutput, error) {
+			if !input.Confirm {
+				return nil, FolderOutput{Message: "Folder revert requires confirm: true"}, nil
+			}
+			wc, err := resolveFolder(ctx, input.FolderInput)
+			if err != nil {
+				return nil, FolderOutput{}, err
+			}
+			folder, err := wc.Client.RevertFolder(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.FolderID)
+			return nil, FolderOutput{Success: err == nil, Folder: folder, Message: "Folder reverted successfully"}, err
+		})
+}
+
+func resolveFolder(ctx context.Context, input FolderInput) (*WorkspaceContext, error) {
+	if strings.TrimSpace(input.FolderID) == "" {
+		return nil, fmt.Errorf("folder ID is required")
+	}
+	return resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
 }

--- a/gtm/tool_groups_test.go
+++ b/gtm/tool_groups_test.go
@@ -77,8 +77,8 @@ func TestDefaultPreservesSurfaceAndAllIncludesOptionalGroups(t *testing.T) {
 	if got := registeredToolCount(t, defaults); got != 64 {
 		t.Fatalf("default=%d, want 64", got)
 	}
-	if got := registeredToolCount(t, all); got != 80 {
-		t.Fatalf("all=%d, want 80", got)
+	if got := registeredToolCount(t, all); got != 89 {
+		t.Fatalf("all=%d, want 89", got)
 	}
 }
 

--- a/gtm/tool_workspace_operations.go
+++ b/gtm/tool_workspace_operations.go
@@ -1,0 +1,98 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type BulkUpdateWorkspaceInput struct {
+	WorkspaceInput
+	ChangesJSON string `json:"changesJson" jsonschema:"description:JSON object containing a non-empty changes array of GTM Entity objects"`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to apply all proposed workspace changes"`
+}
+
+type BulkUpdateWorkspaceOutput struct {
+	Success bool   `json:"success"`
+	Changes any    `json:"changes,omitempty"`
+	Message string `json:"message"`
+}
+
+type ResolveWorkspaceConflictInput struct {
+	WorkspaceInput
+	Fingerprint string `json:"fingerprint" jsonschema:"description:Fingerprint of entityInWorkspace from the merge conflict"`
+	EntityJSON  string `json:"entityJson" jsonschema:"description:The fully resolved GTM Entity as JSON"`
+	Confirm     bool   `json:"confirm" jsonschema:"description:Must be true to replace the conflicting entity"`
+}
+
+type WorkspaceActionOutput struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+type SyncWorkspaceInput struct {
+	WorkspaceInput
+	Confirm bool `json:"confirm" jsonschema:"description:Must be true to synchronize the workspace"`
+}
+
+type SyncWorkspaceOutput struct {
+	Success bool                `json:"success"`
+	Result  WorkspaceSyncResult `json:"result"`
+	Message string              `json:"message"`
+}
+
+func registerBulkUpdateWorkspace(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "bulk_update_workspace", Description: "Apply multiple GTM entity changes atomically. Requires confirm: true; new IDs must use the new_N format."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input BulkUpdateWorkspaceInput) (*mcp.CallToolResult, BulkUpdateWorkspaceOutput, error) {
+			if !input.Confirm {
+				return nil, BulkUpdateWorkspaceOutput{Message: "Workspace bulk update requires confirm: true"}, nil
+			}
+			if strings.TrimSpace(input.ChangesJSON) == "" {
+				return nil, BulkUpdateWorkspaceOutput{}, fmt.Errorf("changesJson is required")
+			}
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, BulkUpdateWorkspaceOutput{}, err
+			}
+			changes, err := wc.Client.BulkUpdateWorkspace(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.ChangesJSON)
+			return nil, BulkUpdateWorkspaceOutput{Success: err == nil, Changes: changes, Message: "Workspace bulk update completed"}, err
+		})
+}
+
+func registerResolveWorkspaceConflict(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "resolve_workspace_conflict", Description: "Replace a conflicting workspace entity with a fully resolved entity. Requires confirm: true and the conflict fingerprint."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input ResolveWorkspaceConflictInput) (*mcp.CallToolResult, WorkspaceActionOutput, error) {
+			if !input.Confirm {
+				return nil, WorkspaceActionOutput{Message: "Conflict resolution requires confirm: true"}, nil
+			}
+			if strings.TrimSpace(input.Fingerprint) == "" || strings.TrimSpace(input.EntityJSON) == "" {
+				return nil, WorkspaceActionOutput{}, fmt.Errorf("fingerprint and entityJson are required")
+			}
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, WorkspaceActionOutput{}, err
+			}
+			err = wc.Client.ResolveWorkspaceConflict(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.Fingerprint, input.EntityJSON)
+			return nil, WorkspaceActionOutput{Success: err == nil, Message: "Workspace conflict resolved"}, err
+		})
+}
+
+func registerSyncWorkspace(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "sync_workspace", Description: "Synchronize a workspace to the latest container version and return any merge conflicts. Requires confirm: true."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input SyncWorkspaceInput) (*mcp.CallToolResult, SyncWorkspaceOutput, error) {
+			if !input.Confirm {
+				return nil, SyncWorkspaceOutput{Message: "Workspace synchronization requires confirm: true"}, nil
+			}
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, SyncWorkspaceOutput{}, err
+			}
+			result, err := wc.Client.SyncWorkspace(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID)
+			if err != nil {
+				return nil, SyncWorkspaceOutput{}, err
+			}
+			return nil, SyncWorkspaceOutput{Success: !result.SyncError, Result: *result, Message: "Workspace synchronized"}, nil
+		})
+}

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -21,7 +21,10 @@ var defaultToolGroupNames = []string{
 	"folders", "builtins", "zones", "templates", "server", "guidance",
 }
 
-var optionalToolGroupNames = []string{"environments", "destinations", "gtag", "container-admin"}
+var optionalToolGroupNames = []string{
+	"environments", "destinations", "gtag", "container-admin",
+	"folder-admin", "workspace-admin",
+}
 
 // ParseToolGroups validates GTM_TOOL_GROUPS. An empty value preserves the
 // complete pre-grouping tool surface. "all" also enables future families.
@@ -124,6 +127,21 @@ func RegisterToolsForGroups(server *mcp.Server, groups ToolGroups) {
 	if groups.enabled("folders") {
 		registerListFolders(server)
 		registerGetFolderEntities(server)
+	}
+
+	if groups.enabled("folder-admin") {
+		registerGetFolder(server)
+		registerCreateFolder(server)
+		registerUpdateFolder(server)
+		registerDeleteFolder(server)
+		registerMoveEntitiesToFolder(server)
+		registerRevertFolder(server)
+	}
+
+	if groups.enabled("workspace-admin") {
+		registerBulkUpdateWorkspace(server)
+		registerResolveWorkspaceConflict(server)
+		registerSyncWorkspace(server)
 	}
 
 	if groups.enabled("zones") {

--- a/gtm/workspace_folders_parity_test.go
+++ b/gtm/workspace_folders_parity_test.go
@@ -1,0 +1,266 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestFolderReadsPaginateAndGetExactPath(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
+		calls := 0
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			if r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/folders" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Query().Get("pageToken") == "" {
+				fmt.Fprint(w, `{"folder":[{"folderId":"4","name":"A","fingerprint":"fp"}],"nextPageToken":"next"}`)
+			} else {
+				fmt.Fprint(w, `{"folder":[{"folderId":"5","name":"B"}]}`)
+			}
+		})
+		got, err := client.ListFolders(context.Background(), "1", "2", "3")
+		if err != nil || calls != 2 || len(got) != 2 || got[0].Fingerprint != "fp" {
+			t.Fatalf("calls=%d folders=%+v err=%v", calls, got, err)
+		}
+	})
+
+	t.Run("entities", func(t *testing.T) {
+		calls := 0
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			if r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/folders/4:entities" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Query().Get("pageToken") == "" {
+				fmt.Fprint(w, `{"tag":[{"name":"Tag A"}],"nextPageToken":"next"}`)
+			} else {
+				fmt.Fprint(w, `{"trigger":[{"name":"Trigger B"}],"variable":[{"name":"Variable C"}]}`)
+			}
+		})
+		got, err := client.GetFolderEntities(context.Background(), "1", "2", "3", "4")
+		if err != nil || calls != 2 || len(got.Tags) != 1 || len(got.Triggers) != 1 || len(got.Variables) != 1 {
+			t.Fatalf("calls=%d entities=%+v err=%v", calls, got, err)
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/folders/4" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"folderId":"4","name":"A","notes":"N","fingerprint":"fp"}`)
+		})
+		got, err := client.GetFolder(context.Background(), "1", "2", "3", "4")
+		if err != nil || got.Name != "A" || got.Notes != "N" {
+			t.Fatalf("folder=%+v err=%v", got, err)
+		}
+	})
+}
+
+func TestFolderMutationsUseFingerprintAndOfficialRoutes(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/folders" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["name"] != "Marketing" || body["notes"] != "Owned" {
+				t.Fatalf("body=%#v err=%v", body, err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"folderId":"4","name":"Marketing"}`)
+		})
+		got, err := client.CreateFolder(context.Background(), "1", "2", "3", "Marketing", "Owned")
+		if err != nil || got.FolderID != "4" {
+			t.Fatalf("folder=%+v err=%v", got, err)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		calls := 0
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.Header().Set("Content-Type", "application/json")
+			if calls == 1 {
+				fmt.Fprint(w, `{"folderId":"4","name":"Keep","notes":"clear","fingerprint":"old"}`)
+				return
+			}
+			if r.Method != http.MethodPut || r.URL.Query().Get("fingerprint") != "old" {
+				t.Errorf("unexpected update: %s %s", r.Method, r.URL)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["name"] != "Keep" || body["notes"] != "" {
+				t.Fatalf("body=%#v err=%v", body, err)
+			}
+			if _, exists := body["folderId"]; exists {
+				t.Errorf("immutable ID sent: %#v", body)
+			}
+			fmt.Fprint(w, `{"folderId":"4","name":"Keep","fingerprint":"new"}`)
+		})
+		empty := ""
+		got, err := client.UpdateFolder(context.Background(), "1", "2", "3", "4", nil, &empty)
+		if err != nil || calls != 2 || got.Fingerprint != "new" {
+			t.Fatalf("calls=%d folder=%+v err=%v", calls, got, err)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/folders/4" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		if err := client.DeleteFolder(context.Background(), "1", "2", "3", "4"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("move entities", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/folders/4:move_entities_to_folder" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			if len(r.URL.Query()["tagId"]) != 2 || r.URL.Query().Get("triggerId") != "7" || r.URL.Query().Get("variableId") != "8" {
+				t.Errorf("unexpected query: %s", r.URL.RawQuery)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		if err := client.MoveEntitiesToFolder(context.Background(), "1", "2", "3", "4", []string{"5", "6"}, []string{"7"}, []string{"8"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("revert", func(t *testing.T) {
+		calls := 0
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.Header().Set("Content-Type", "application/json")
+			if calls == 1 {
+				fmt.Fprint(w, `{"folderId":"4","fingerprint":"old"}`)
+				return
+			}
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/folders/4:revert" || r.URL.Query().Get("fingerprint") != "old" {
+				t.Errorf("unexpected revert: %s %s", r.Method, r.URL)
+			}
+			fmt.Fprint(w, `{"folder":{"folderId":"4","name":"Restored"}}`)
+		})
+		got, err := client.RevertFolder(context.Background(), "1", "2", "3", "4")
+		if err != nil || calls != 2 || got.Name != "Restored" {
+			t.Fatalf("calls=%d folder=%+v err=%v", calls, got, err)
+		}
+	})
+}
+
+func TestWorkspaceOperationsUseOfficialPayloadsAndRoutes(t *testing.T) {
+	t.Run("bulk update", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/bulk_update" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["changes"] == nil {
+				t.Fatalf("body=%#v err=%v", body, err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"changes":[{"changeStatus":"added","folder":{"folderId":"new_1","name":"New"}}]}`)
+		})
+		changes, err := client.BulkUpdateWorkspace(context.Background(), "1", "2", "3", `{"changes":[{"changeStatus":"added","folder":{"folderId":"new_1","name":"New"}}]}`)
+		if err != nil || changes == nil {
+			t.Fatalf("changes=%+v err=%v", changes, err)
+		}
+	})
+
+	t.Run("resolve conflict", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3:resolve_conflict" || r.URL.Query().Get("fingerprint") != "fp" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		if err := client.ResolveWorkspaceConflict(context.Background(), "1", "2", "3", "fp", `{"changeStatus":"updated","folder":{"folderId":"4","name":"Resolved"}}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("sync", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3:sync" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"syncStatus":{"mergeConflict":true,"syncError":false},"mergeConflict":[{"entityInWorkspace":{"changeStatus":"updated"}}]}`)
+		})
+		got, err := client.SyncWorkspace(context.Background(), "1", "2", "3")
+		if err != nil || !got.MergeConflict || got.SyncError || got.Conflicts == nil {
+			t.Fatalf("result=%+v err=%v", got, err)
+		}
+	})
+}
+
+func TestWorkspaceFolderConfirmationGuardsRunBeforeAuth(t *testing.T) {
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	registerDeleteFolder(server)
+	registerMoveEntitiesToFolder(server)
+	registerRevertFolder(server)
+	registerBulkUpdateWorkspace(server)
+	registerResolveWorkspaceConflict(server)
+	registerSyncWorkspace(server)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	workspace := map[string]any{"accountId": "1", "containerId": "2", "workspaceId": "3", "confirm": false}
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{"delete_folder", mergeArgs(workspace, map[string]any{"folderId": "4"})},
+		{"move_entities_to_folder", mergeArgs(workspace, map[string]any{"folderId": "4", "tagIds": []string{"5"}})},
+		{"revert_folder", mergeArgs(workspace, map[string]any{"folderId": "4"})},
+		{"bulk_update_workspace", mergeArgs(workspace, map[string]any{"changesJson": `{"changes":[]}`})},
+		{"resolve_workspace_conflict", mergeArgs(workspace, map[string]any{"fingerprint": "fp", "entityJson": `{}`})},
+		{"sync_workspace", workspace},
+	}
+	for _, tc := range cases {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{Name: tc.name, Arguments: tc.args})
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		encoded, _ := json.Marshal(result)
+		if strings.Contains(string(encoded), "not authenticated") {
+			t.Fatalf("%s reached authentication before confirmation: %s", tc.name, encoded)
+		}
+	}
+}
+
+func mergeArgs(base, extra map[string]any) map[string]any {
+	result := make(map[string]any, len(base)+len(extra))
+	for key, value := range base {
+		result[key] = value
+	}
+	for key, value := range extra {
+		result[key] = value
+	}
+	return result
+}

--- a/gtm/workspace_operations.go
+++ b/gtm/workspace_operations.go
@@ -1,0 +1,51 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+type WorkspaceSyncResult struct {
+	MergeConflict bool `json:"mergeConflict"`
+	SyncError     bool `json:"syncError"`
+	Conflicts     any  `json:"conflicts,omitempty"`
+}
+
+func (c *Client) BulkUpdateWorkspace(ctx context.Context, accountID, containerID, workspaceID, changesJSON string) (any, error) {
+	var proposed tagmanager.ProposedChange
+	if err := json.Unmarshal([]byte(changesJSON), &proposed); err != nil {
+		return nil, fmt.Errorf("invalid changesJson: %w", err)
+	}
+	if len(proposed.Changes) == 0 {
+		return nil, fmt.Errorf("changesJson must contain a non-empty changes array")
+	}
+	response, err := c.Service.Accounts.Containers.Workspaces.BulkUpdate(BuildWorkspacePath(accountID, containerID, workspaceID), &proposed).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	return response.Changes, nil
+}
+
+func (c *Client) ResolveWorkspaceConflict(ctx context.Context, accountID, containerID, workspaceID, fingerprint, entityJSON string) error {
+	var entity tagmanager.Entity
+	if err := json.Unmarshal([]byte(entityJSON), &entity); err != nil {
+		return fmt.Errorf("invalid entityJson: %w", err)
+	}
+	return mapGoogleError(c.Service.Accounts.Containers.Workspaces.ResolveConflict(BuildWorkspacePath(accountID, containerID, workspaceID), &entity).Fingerprint(fingerprint).Context(ctx).Do())
+}
+
+func (c *Client) SyncWorkspace(ctx context.Context, accountID, containerID, workspaceID string) (*WorkspaceSyncResult, error) {
+	response, err := c.Service.Accounts.Containers.Workspaces.Sync(BuildWorkspacePath(accountID, containerID, workspaceID)).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := &WorkspaceSyncResult{Conflicts: response.MergeConflict}
+	if response.SyncStatus != nil {
+		result.MergeConflict = response.SyncStatus.MergeConflict
+		result.SyncError = response.SyncStatus.SyncError
+	}
+	return result, nil
+}

--- a/llms.txt
+++ b/llms.txt
@@ -47,6 +47,7 @@ Always discover IDs by listing — never guess or hardcode them.
 | `list_variables` | List all variables in a workspace |
 | `get_variable` | Get full variable details by ID |
 | `list_folders` | List folders in a workspace |
+| `get_folder` | Get complete folder metadata |
 | `get_folder_entities` | Get tags/triggers/variables in a specific folder |
 | `list_zones` | List zones in a workspace |
 | `get_zone` | Get a zone and its configuration |
@@ -77,6 +78,14 @@ Always discover IDs by listing — never guess or hardcode them.
 | `create_workspace` | Create a new workspace |
 | `update_workspace` | Update a workspace name or description |
 | `delete_workspace` | Delete a workspace and pending changes (requires `confirm: true`) |
+| `bulk_update_workspace` | Apply multiple entity changes (requires `confirm: true`) |
+| `resolve_workspace_conflict` | Replace a conflicting entity (requires `confirm: true`) |
+| `sync_workspace` | Synchronize with the latest version (requires `confirm: true`) |
+| `create_folder` | Create a workspace folder |
+| `update_folder` | Update a workspace folder |
+| `delete_folder` | Delete a workspace folder (requires `confirm: true`) |
+| `move_entities_to_folder` | Move entities into a folder (requires `confirm: true`) |
+| `revert_folder` | Discard workspace changes to a folder (requires `confirm: true`) |
 | `create_environment` | Create a user environment |
 | `update_environment` | Update a user environment with fingerprint protection |
 | `reauthorize_environment` | Rotate an environment authorization code (requires `confirm: true`) |


### PR DESCRIPTION
Adds the nine missing workspace and folder methods, raising official GTM API coverage from 80/106 to 89/106 after #119.

Workspace support now includes bulk update, conflict resolution, and sync. Folder support now includes get/create/update/delete, moving entities, and reverting changes. Mutation tools require confirmation where they discard, move, or apply multiple changes. Updates and reverts use current fingerprints, while raw Entity JSON preserves the official API's full entity surface.

This also fixes pagination in the existing `list_folders` and `get_folder_entities` methods.

This PR is stacked on #119. Once the earlier PRs merge, GitHub will show only this commit's changes against `main`.

Validation:

- `go test ./... -count=1`
- `go vet ./...`
- `staticcheck ./...`
- schema report: default remains 64 tools / 78,734 bytes; `all` is 89 tools / 109,447 bytes
