### PR TITLE
feat: complete GTM API parity scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,17 @@ service-account authentication for self-hosted automation.
 |---|---|
 | Version in `server.json` | `1.10.1` |
 | Transport | MCP Streamable HTTP |
-| Runtime tools | 64 GTM tools by default; 89 with `GTM_TOOL_GROUPS=all`, plus 2 utility tools |
+| Runtime tools | 64 GTM tools by default; 94 with `GTM_TOOL_GROUPS=all`, plus 2 utility tools |
 | MCP resources | 8 resource definitions |
 | MCP prompts | 6 prompts |
-| Official GTM API coverage | 89 of 106 methods |
-| Planned parity target | 101 of 106 methods |
+| Official GTM API coverage | 101 of 106 methods |
+| Product parity target | 101 of 106 methods, reached |
 | Hosted endpoint | `https://mcp.gtmeditor.com` |
 
-API parity is **not complete**. The project has implemented 89 methods from
-Google's 106-method GTM v2 discovery surface. Another 12 methods are planned.
-The five `accounts.user_permissions` methods are intentionally excluded because
-granting and revoking GTM access needs a separate privilege-management design.
-
-The remaining roadmap includes version state changes and resource revert
-operations.
+The agreed API parity scope is complete. The project implements 101 methods
+from Google's 106-method GTM v2 discovery surface. The five
+`accounts.user_permissions` methods are intentionally excluded because granting
+and revoking GTM access needs a separate privilege-management design.
 
 Tool count and API-method count are different. Some tools provide local
 guidance, while some helpers cover more than one Google API call.
@@ -222,7 +219,7 @@ GTM drops `autoEventFilter` for those trigger types.
 | `enable_built_in_variables` | Enable built-in variable types |
 | `disable_built_in_variables` | Disable built-in variable types; requires `confirm: true` |
 
-Built-in-variable revert remains on the parity roadmap.
+Use `revert_workspace_entity` to discard changes to a built-in variable.
 
 ### Zones
 
@@ -234,7 +231,7 @@ Built-in-variable revert remains on the parity roadmap.
 | `update_zone` | Update selected fields with fingerprint concurrency control |
 | `delete_zone` | Delete a zone; requires `confirm: true` |
 
-Zone revert remains in the later cross-resource revert slice.
+Use `revert_workspace_entity` to discard changes to a zone.
 
 ### Environments
 
@@ -304,7 +301,7 @@ not repeat them.
 | `update_transformation` | Update a transformation |
 | `delete_transformation` | Delete a transformation; requires `confirm: true` |
 
-Client and transformation revert methods remain on the parity roadmap.
+Use `revert_workspace_entity` to discard changes to a client or transformation.
 
 ### Versions and publication
 
@@ -316,8 +313,20 @@ Client and transformation revert methods remain on the parity roadmap.
 | `get_live_version` | Get the currently published version and its entities |
 | `create_version` | Create a version from a conflict-free workspace |
 | `publish_version` | Publish a selected version; requires `confirm: true` |
+| `update_version` | Update a saved version's name or description |
+| `delete_version` | Soft-delete a version; requires `confirm: true` |
+| `undelete_version` | Restore a soft-deleted version; requires `confirm: true` |
+| `set_latest_version` | Make a version Latest without publishing; requires `confirm: true` |
 
-Version delete, set-latest, undelete, and update remain on the parity roadmap.
+### Workspace reverts
+
+| Tool | Purpose |
+|---|---|
+| `revert_workspace_entity` | Discard workspace changes to a built-in variable, client, tag, template, transformation, trigger, variable, or zone; requires `confirm: true` |
+
+The tool fetches the current entity fingerprint before calling the matching
+official revert method. A successful result can have `existsAfterRevert: false`
+when the entity does not exist in the latest container version.
 
 ## Safety model
 
@@ -497,9 +506,9 @@ hosts.
 API. Available groups are `accounts`, `workspaces`, `tags`, `triggers`,
 `variables`, `folders`, `builtins`, `zones`, `templates`, `server`, `guidance`,
 `environments`, `destinations`, `gtag`, `container-admin`, `folder-admin`, and
-`workspace-admin`. Leaving it unset preserves the established 64-tool surface.
-New parity groups are opt-in. Use `all` to include every current and future
-parity family, or select a subset:
+`workspace-admin`, `version-admin`, and `reverts`. Leaving it unset preserves
+the established 64-tool surface. New parity groups are opt-in. Use `all` to
+include every current and future parity family, or select a subset:
 
 ```text
 GTM_TOOL_GROUPS=accounts,workspaces,tags,triggers,variables
@@ -551,7 +560,7 @@ The schema report prints the GTM tool count, serialized `tools/list` size, token
 estimate, and largest definitions. The default GTM tool surface serializes to
 78,734 bytes for 64 tools. A regression test enforces an 80,000-byte ceiling so
 new parity work does not silently consume unlimited model context. The `all`
-group exposes 89 GTM tools and serializes to 109,447 bytes.
+group exposes 94 GTM tools and serializes to 115,748 bytes.
 
 Pull requests run `govulncheck`, `gosec`, Gitleaks, Trivy, `staticcheck`, and
 CodeQL. Request-level GTM tests use local fake Google endpoints. Mutating live
@@ -565,9 +574,8 @@ For a deep dive into the Google Tag Manager MCP server, read the [Deep Wiki](htt
 
 ## Current limitations
 
-- Official GTM v2 API parity is 89/106, with a target of 101/106.
-- The five account user-permission methods are outside the current product
-  scope.
+- The 101-method GTM v2 API parity target is complete. The five account
+  user-permission methods remain outside the product scope.
 - The server supports Streamable HTTP only. Stdio transport is planned but is
   not implemented.
 - The optional connection dashboard is under review in

--- a/gtm/final_parity_test.go
+++ b/gtm/final_parity_test.go
@@ -1,0 +1,177 @@
+package gtm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestVersionLifecycleUsesOfficialRoutes(t *testing.T) {
+	t.Run("delete", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/versions/3" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		if err := client.DeleteVersion(context.Background(), "1", "2", "3"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name, suffix string
+		call         func(*Client) (*VersionLifecycle, error)
+	}{
+		{"undelete", ":undelete", func(c *Client) (*VersionLifecycle, error) {
+			return c.UndeleteVersion(context.Background(), "1", "2", "3")
+		}},
+		{"set latest", ":set_latest", func(c *Client) (*VersionLifecycle, error) {
+			return c.SetLatestVersion(context.Background(), "1", "2", "3")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/versions/3"+tc.suffix {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"containerVersionId":"3","name":"Release","description":"D","fingerprint":"fp"}`)
+			})
+			got, err := tc.call(client)
+			if err != nil || got.VersionID != "3" || got.Description != "D" {
+				t.Fatalf("version=%+v err=%v", got, err)
+			}
+		})
+	}
+
+	t.Run("update", func(t *testing.T) {
+		calls := 0
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.Header().Set("Content-Type", "application/json")
+			if calls == 1 {
+				if r.Method != http.MethodGet {
+					t.Errorf("first method=%s", r.Method)
+				}
+				fmt.Fprint(w, `{"containerVersionId":"3","name":"Keep","description":"clear","fingerprint":"old"}`)
+				return
+			}
+			if r.Method != http.MethodPut || r.URL.Query().Get("fingerprint") != "old" {
+				t.Errorf("unexpected update: %s %s", r.Method, r.URL)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["name"] != "Keep" || body["description"] != "" {
+				t.Fatalf("body=%#v err=%v", body, err)
+			}
+			if _, exists := body["containerVersionId"]; exists {
+				t.Errorf("immutable ID sent: %#v", body)
+			}
+			fmt.Fprint(w, `{"containerVersionId":"3","name":"Keep","fingerprint":"new"}`)
+		})
+		empty := ""
+		got, err := client.UpdateVersion(context.Background(), "1", "2", "3", nil, &empty)
+		if err != nil || calls != 2 || got.Fingerprint != "new" {
+			t.Fatalf("calls=%d version=%+v err=%v", calls, got, err)
+		}
+	})
+}
+
+func TestEveryWorkspaceResourceRevertUsesFingerprint(t *testing.T) {
+	cases := []struct {
+		kind, segment, response string
+	}{
+		{"client", "clients", `{"client":{"clientId":"4","name":"Restored"}}`},
+		{"tag", "tags", `{"tag":{"tagId":"4","name":"Restored"}}`},
+		{"template", "templates", `{"template":{"templateId":"4","name":"Restored"}}`},
+		{"transformation", "transformations", `{"transformation":{"transformationId":"4","name":"Restored"}}`},
+		{"trigger", "triggers", `{"trigger":{"triggerId":"4","name":"Restored"}}`},
+		{"variable", "variables", `{"variable":{"variableId":"4","name":"Restored"}}`},
+		{"zone", "zones", `{"zone":{"zoneId":"4","name":"Restored"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			calls := 0
+			client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				expected := "/tagmanager/v2/accounts/1/containers/2/workspaces/3/" + tc.segment + "/4"
+				w.Header().Set("Content-Type", "application/json")
+				if calls == 1 {
+					if r.Method != http.MethodGet || r.URL.Path != expected {
+						t.Errorf("unexpected get: %s %s", r.Method, r.URL)
+					}
+					fmt.Fprint(w, `{"fingerprint":"old"}`)
+					return
+				}
+				if r.Method != http.MethodPost || r.URL.Path != expected+":revert" || r.URL.Query().Get("fingerprint") != "old" {
+					t.Errorf("unexpected revert: %s %s", r.Method, r.URL)
+				}
+				fmt.Fprint(w, tc.response)
+			})
+			got, err := client.RevertWorkspaceEntity(context.Background(), "1", "2", "3", tc.kind, "4")
+			if err != nil || calls != 2 || !got.ExistsAfterRevert || got.Resource == nil {
+				t.Fatalf("calls=%d result=%+v err=%v", calls, got, err)
+			}
+		})
+	}
+
+	t.Run("built-in variable", func(t *testing.T) {
+		client := versionTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/tagmanager/v2/accounts/1/containers/2/workspaces/3/built_in_variables:revert" || r.URL.Query().Get("type") != "pageUrl" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"enabled":true}`)
+		})
+		got, err := client.RevertWorkspaceEntity(context.Background(), "1", "2", "3", "builtInVariable", "pageUrl")
+		if err != nil || !got.ExistsAfterRevert {
+			t.Fatalf("result=%+v err=%v", got, err)
+		}
+	})
+}
+
+func TestFinalParityConfirmationGuardsRunBeforeAuth(t *testing.T) {
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	registerDeleteVersion(server)
+	registerUndeleteVersion(server)
+	registerSetLatestVersion(server)
+	registerRevertWorkspaceEntity(server)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{"delete_version", map[string]any{"accountId": "1", "containerId": "2", "versionId": "3", "confirm": false}},
+		{"undelete_version", map[string]any{"accountId": "1", "containerId": "2", "versionId": "3", "confirm": false}},
+		{"set_latest_version", map[string]any{"accountId": "1", "containerId": "2", "versionId": "3", "confirm": false}},
+		{"revert_workspace_entity", map[string]any{"accountId": "1", "containerId": "2", "workspaceId": "3", "resourceType": "tag", "resourceId": "4", "confirm": false}},
+	}
+	for _, tc := range cases {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{Name: tc.name, Arguments: tc.args})
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		encoded, _ := json.Marshal(result)
+		if strings.Contains(string(encoded), "not authenticated") {
+			t.Fatalf("%s reached authentication before confirmation: %s", tc.name, encoded)
+		}
+	}
+}

--- a/gtm/reverts.go
+++ b/gtm/reverts.go
@@ -1,0 +1,108 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+)
+
+type RevertResult struct {
+	ResourceType      string `json:"resourceType"`
+	ResourceID        string `json:"resourceId"`
+	ExistsAfterRevert bool   `json:"existsAfterRevert"`
+	Resource          any    `json:"resource,omitempty"`
+}
+
+func (c *Client) RevertWorkspaceEntity(ctx context.Context, accountID, containerID, workspaceID, resourceType, resourceID string) (*RevertResult, error) {
+	workspacePath := BuildWorkspacePath(accountID, containerID, workspaceID)
+	result := &RevertResult{ResourceType: resourceType, ResourceID: resourceID}
+
+	switch resourceType {
+	case "builtInVariable":
+		response, err := c.Service.Accounts.Containers.Workspaces.BuiltInVariables.Revert(workspacePath).Type(resourceID).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result.ExistsAfterRevert = response.Enabled
+		result.Resource = map[string]any{"type": resourceID, "enabled": response.Enabled}
+	case "client":
+		path := BuildClientPath(accountID, containerID, workspaceID, resourceID)
+		current, err := c.Service.Accounts.Containers.Workspaces.Clients.Get(path).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		response, err := c.Service.Accounts.Containers.Workspaces.Clients.Revert(path).Fingerprint(current.Fingerprint).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result.ExistsAfterRevert, result.Resource = response.Client != nil, response.Client
+	case "tag":
+		path := BuildTagPath(accountID, containerID, workspaceID, resourceID)
+		current, err := c.Service.Accounts.Containers.Workspaces.Tags.Get(path).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		response, err := c.Service.Accounts.Containers.Workspaces.Tags.Revert(path).Fingerprint(current.Fingerprint).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result.ExistsAfterRevert, result.Resource = response.Tag != nil, response.Tag
+	case "template":
+		path := fmt.Sprintf("%s/templates/%s", workspacePath, resourceID)
+		current, err := c.Service.Accounts.Containers.Workspaces.Templates.Get(path).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		response, err := c.Service.Accounts.Containers.Workspaces.Templates.Revert(path).Fingerprint(current.Fingerprint).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result.ExistsAfterRevert, result.Resource = response.Template != nil, response.Template
+	case "transformation":
+		path := BuildTransformationPath(accountID, containerID, workspaceID, resourceID)
+		current, err := c.Service.Accounts.Containers.Workspaces.Transformations.Get(path).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		response, err := c.Service.Accounts.Containers.Workspaces.Transformations.Revert(path).Fingerprint(current.Fingerprint).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result.ExistsAfterRevert, result.Resource = response.Transformation != nil, response.Transformation
+	case "trigger":
+		path := BuildTriggerPath(accountID, containerID, workspaceID, resourceID)
+		current, err := c.Service.Accounts.Containers.Workspaces.Triggers.Get(path).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		response, err := c.Service.Accounts.Containers.Workspaces.Triggers.Revert(path).Fingerprint(current.Fingerprint).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result.ExistsAfterRevert, result.Resource = response.Trigger != nil, response.Trigger
+	case "variable":
+		path := BuildVariablePath(accountID, containerID, workspaceID, resourceID)
+		current, err := c.Service.Accounts.Containers.Workspaces.Variables.Get(path).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		response, err := c.Service.Accounts.Containers.Workspaces.Variables.Revert(path).Fingerprint(current.Fingerprint).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result.ExistsAfterRevert, result.Resource = response.Variable != nil, response.Variable
+	case "zone":
+		path := BuildZonePath(accountID, containerID, workspaceID, resourceID)
+		current, err := c.Service.Accounts.Containers.Workspaces.Zones.Get(path).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		response, err := c.Service.Accounts.Containers.Workspaces.Zones.Revert(path).Fingerprint(current.Fingerprint).Context(ctx).Do()
+		if err != nil {
+			return nil, mapGoogleError(err)
+		}
+		result.ExistsAfterRevert, result.Resource = response.Zone != nil, response.Zone
+	default:
+		return nil, fmt.Errorf("unsupported resource type %q", resourceType)
+	}
+	return result, nil
+}

--- a/gtm/tool_groups_test.go
+++ b/gtm/tool_groups_test.go
@@ -77,8 +77,8 @@ func TestDefaultPreservesSurfaceAndAllIncludesOptionalGroups(t *testing.T) {
 	if got := registeredToolCount(t, defaults); got != 64 {
 		t.Fatalf("default=%d, want 64", got)
 	}
-	if got := registeredToolCount(t, all); got != 89 {
-		t.Fatalf("all=%d, want 89", got)
+	if got := registeredToolCount(t, all); got != 94 {
+		t.Fatalf("all=%d, want 94", got)
 	}
 }
 

--- a/gtm/tool_reverts.go
+++ b/gtm/tool_reverts.go
@@ -1,0 +1,40 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type RevertWorkspaceEntityInput struct {
+	WorkspaceInput
+	ResourceType string `json:"resourceType" jsonschema:"description:Resource family: builtInVariable, client, tag, template, transformation, trigger, variable, or zone"`
+	ResourceID   string `json:"resourceId" jsonschema:"description:Entity ID, or the built-in variable type for builtInVariable"`
+	Confirm      bool   `json:"confirm" jsonschema:"description:Must be true to discard the entity's workspace changes"`
+}
+
+type RevertWorkspaceEntityOutput struct {
+	Success bool          `json:"success"`
+	Result  *RevertResult `json:"result,omitempty"`
+	Message string        `json:"message"`
+}
+
+func registerRevertWorkspaceEntity(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "revert_workspace_entity", Description: "Discard workspace changes to a built-in variable, client, tag, template, transformation, trigger, variable, or zone. Requires confirm: true and uses the current fingerprint."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input RevertWorkspaceEntityInput) (*mcp.CallToolResult, RevertWorkspaceEntityOutput, error) {
+			if !input.Confirm {
+				return nil, RevertWorkspaceEntityOutput{Message: "Entity revert requires confirm: true"}, nil
+			}
+			if strings.TrimSpace(input.ResourceType) == "" || strings.TrimSpace(input.ResourceID) == "" {
+				return nil, RevertWorkspaceEntityOutput{}, fmt.Errorf("resourceType and resourceId are required")
+			}
+			wc, err := resolveWorkspace(ctx, input.AccountID, input.ContainerID, input.WorkspaceID)
+			if err != nil {
+				return nil, RevertWorkspaceEntityOutput{}, err
+			}
+			result, err := wc.Client.RevertWorkspaceEntity(ctx, wc.AccountID, wc.ContainerID, wc.WorkspaceID, input.ResourceType, input.ResourceID)
+			return nil, RevertWorkspaceEntityOutput{Success: err == nil, Result: result, Message: "Workspace entity reverted successfully"}, err
+		})
+}

--- a/gtm/tool_version_lifecycle.go
+++ b/gtm/tool_version_lifecycle.go
@@ -1,0 +1,99 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type VersionLifecycleInput struct {
+	AccountID   string `json:"accountId" jsonschema:"description:The GTM account ID"`
+	ContainerID string `json:"containerId" jsonschema:"description:The GTM container ID"`
+	VersionID   string `json:"versionId" jsonschema:"description:The container version ID"`
+}
+
+type ConfirmVersionLifecycleInput struct {
+	VersionLifecycleInput
+	Confirm bool `json:"confirm" jsonschema:"description:Must be true to confirm the version state change"`
+}
+
+type UpdateVersionInput struct {
+	VersionLifecycleInput
+	Name        *string `json:"name,omitempty" jsonschema:"description:New version name; omit to preserve or pass empty to clear"`
+	Description *string `json:"description,omitempty" jsonschema:"description:New version description; omit to preserve or pass empty to clear"`
+}
+
+type VersionLifecycleOutput struct {
+	Success bool              `json:"success"`
+	Version *VersionLifecycle `json:"version,omitempty"`
+	Message string            `json:"message"`
+}
+
+func registerDeleteVersion(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "delete_version", Description: "Soft-delete a container version. Requires confirm: true and can be reversed with undelete_version."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input ConfirmVersionLifecycleInput) (*mcp.CallToolResult, VersionLifecycleOutput, error) {
+			if !input.Confirm {
+				return nil, VersionLifecycleOutput{Message: "Version deletion requires confirm: true"}, nil
+			}
+			cc, err := resolveVersionLifecycle(ctx, input.VersionLifecycleInput)
+			if err != nil {
+				return nil, VersionLifecycleOutput{}, err
+			}
+			err = cc.Client.DeleteVersion(ctx, cc.AccountID, cc.ContainerID, input.VersionID)
+			return nil, VersionLifecycleOutput{Success: err == nil, Message: "Version deleted successfully"}, err
+		})
+}
+
+func registerUndeleteVersion(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "undelete_version", Description: "Restore a soft-deleted container version. Requires confirm: true."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input ConfirmVersionLifecycleInput) (*mcp.CallToolResult, VersionLifecycleOutput, error) {
+			if !input.Confirm {
+				return nil, VersionLifecycleOutput{Message: "Version restoration requires confirm: true"}, nil
+			}
+			cc, err := resolveVersionLifecycle(ctx, input.VersionLifecycleInput)
+			if err != nil {
+				return nil, VersionLifecycleOutput{}, err
+			}
+			version, err := cc.Client.UndeleteVersion(ctx, cc.AccountID, cc.ContainerID, input.VersionID)
+			return nil, VersionLifecycleOutput{Success: err == nil, Version: version, Message: "Version restored successfully"}, err
+		})
+}
+
+func registerSetLatestVersion(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "set_latest_version", Description: "Set a container version as Latest without publishing it Live. Requires confirm: true."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input ConfirmVersionLifecycleInput) (*mcp.CallToolResult, VersionLifecycleOutput, error) {
+			if !input.Confirm {
+				return nil, VersionLifecycleOutput{Message: "Changing the Latest version requires confirm: true"}, nil
+			}
+			cc, err := resolveVersionLifecycle(ctx, input.VersionLifecycleInput)
+			if err != nil {
+				return nil, VersionLifecycleOutput{}, err
+			}
+			version, err := cc.Client.SetLatestVersion(ctx, cc.AccountID, cc.ContainerID, input.VersionID)
+			return nil, VersionLifecycleOutput{Success: err == nil, Version: version, Message: "Latest version updated successfully"}, err
+		})
+}
+
+func registerUpdateVersion(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: "update_version", Description: "Update a saved version's name or description with fingerprint concurrency control."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateVersionInput) (*mcp.CallToolResult, VersionLifecycleOutput, error) {
+			if input.Name == nil && input.Description == nil {
+				return nil, VersionLifecycleOutput{}, fmt.Errorf("provide name or description to update")
+			}
+			cc, err := resolveVersionLifecycle(ctx, input.VersionLifecycleInput)
+			if err != nil {
+				return nil, VersionLifecycleOutput{}, err
+			}
+			version, err := cc.Client.UpdateVersion(ctx, cc.AccountID, cc.ContainerID, input.VersionID, input.Name, input.Description)
+			return nil, VersionLifecycleOutput{Success: err == nil, Version: version, Message: "Version updated successfully"}, err
+		})
+}
+
+func resolveVersionLifecycle(ctx context.Context, input VersionLifecycleInput) (*ContainerContext, error) {
+	if strings.TrimSpace(input.VersionID) == "" {
+		return nil, fmt.Errorf("version ID is required")
+	}
+	return resolveContainer(ctx, input.AccountID, input.ContainerID)
+}

--- a/gtm/tools.go
+++ b/gtm/tools.go
@@ -23,7 +23,7 @@ var defaultToolGroupNames = []string{
 
 var optionalToolGroupNames = []string{
 	"environments", "destinations", "gtag", "container-admin",
-	"folder-admin", "workspace-admin",
+	"folder-admin", "workspace-admin", "version-admin", "reverts",
 }
 
 // ParseToolGroups validates GTM_TOOL_GROUPS. An empty value preserves the
@@ -142,6 +142,17 @@ func RegisterToolsForGroups(server *mcp.Server, groups ToolGroups) {
 		registerBulkUpdateWorkspace(server)
 		registerResolveWorkspaceConflict(server)
 		registerSyncWorkspace(server)
+	}
+
+	if groups.enabled("version-admin") {
+		registerDeleteVersion(server)
+		registerUndeleteVersion(server)
+		registerSetLatestVersion(server)
+		registerUpdateVersion(server)
+	}
+
+	if groups.enabled("reverts") {
+		registerRevertWorkspaceEntity(server)
 	}
 
 	if groups.enabled("zones") {

--- a/gtm/version_lifecycle.go
+++ b/gtm/version_lifecycle.go
@@ -1,0 +1,84 @@
+package gtm
+
+import (
+	"context"
+	"fmt"
+
+	tagmanager "google.golang.org/api/tagmanager/v2"
+)
+
+type VersionLifecycle struct {
+	AccountID     string `json:"accountId,omitempty"`
+	ContainerID   string `json:"containerId,omitempty"`
+	VersionID     string `json:"containerVersionId"`
+	Name          string `json:"name,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Deleted       bool   `json:"deleted,omitempty"`
+	Fingerprint   string `json:"fingerprint,omitempty"`
+	Path          string `json:"path"`
+	TagManagerURL string `json:"tagManagerUrl,omitempty"`
+}
+
+func (c *Client) DeleteVersion(ctx context.Context, accountID, containerID, versionID string) error {
+	return mapGoogleError(c.Service.Accounts.Containers.Versions.Delete(BuildVersionPath(accountID, containerID, versionID)).Context(ctx).Do())
+}
+
+func (c *Client) UndeleteVersion(ctx context.Context, accountID, containerID, versionID string) (*VersionLifecycle, error) {
+	version, err := c.Service.Accounts.Containers.Versions.Undelete(BuildVersionPath(accountID, containerID, versionID)).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toVersionLifecycle(version)
+	return &result, nil
+}
+
+func (c *Client) SetLatestVersion(ctx context.Context, accountID, containerID, versionID string) (*VersionLifecycle, error) {
+	version, err := c.Service.Accounts.Containers.Versions.SetLatest(BuildVersionPath(accountID, containerID, versionID)).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toVersionLifecycle(version)
+	return &result, nil
+}
+
+func (c *Client) UpdateVersion(ctx context.Context, accountID, containerID, versionID string, name, description *string) (*VersionLifecycle, error) {
+	path := BuildVersionPath(accountID, containerID, versionID)
+	current, err := retryWithBackoff(ctx, 3, func() (*tagmanager.ContainerVersion, error) {
+		return c.Service.Accounts.Containers.Versions.Get(path).Context(ctx).Do()
+	})
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	body := &tagmanager.ContainerVersion{Name: current.Name, Description: current.Description}
+	if name != nil {
+		body.Name = *name
+		if *name == "" {
+			body.ForceSendFields = append(body.ForceSendFields, "Name")
+		}
+	}
+	if description != nil {
+		body.Description = *description
+		if *description == "" {
+			body.ForceSendFields = append(body.ForceSendFields, "Description")
+		}
+	}
+	version, err := c.Service.Accounts.Containers.Versions.Update(path, body).Fingerprint(current.Fingerprint).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGoogleError(err)
+	}
+	result := toVersionLifecycle(version)
+	return &result, nil
+}
+
+func BuildVersionPath(accountID, containerID, versionID string) string {
+	return fmt.Sprintf("%s/versions/%s", BuildContainerPath(accountID, containerID), versionID)
+}
+
+func toVersionLifecycle(version *tagmanager.ContainerVersion) VersionLifecycle {
+	return VersionLifecycle{
+		AccountID: version.AccountId, ContainerID: version.ContainerId,
+		VersionID: version.ContainerVersionId, Name: version.Name, Description: version.Description,
+		Deleted: version.Deleted, Fingerprint: version.Fingerprint, Path: version.Path,
+		TagManagerURL: version.TagManagerUrl,
+	}
+}

--- a/llms.txt
+++ b/llms.txt
@@ -96,6 +96,11 @@ Always discover IDs by listing — never guess or hardcode them.
 | `delete_google_tag_config` | Delete a Google tag configuration (requires `confirm: true`) |
 | `combine_containers` | Merge one container into another (requires `confirm: true`) |
 | `move_tag_id` | Move a tag ID to a new container (requires confirmation and terms acceptance) |
+| `update_version` | Update a saved version's name or description |
+| `delete_version` | Soft-delete a saved version (requires `confirm: true`) |
+| `undelete_version` | Restore a deleted version (requires `confirm: true`) |
+| `set_latest_version` | Make a version Latest without publishing (requires `confirm: true`) |
+| `revert_workspace_entity` | Revert a built-in variable, client, tag, template, transformation, trigger, variable, or zone (requires `confirm: true`) |
 | `update_account` | Rename a GTM account |
 | `enable_built_in_variables` | Enable built-in variable types |
 | `disable_built_in_variables` | Disable built-in variable types (requires `confirm: true`) |


### PR DESCRIPTION
Completes the agreed 101/106 GTM v2 API parity scope. The five excluded methods are all under `accounts.user_permissions` and remain outside the product's privilege-management boundary.

This final slice adds version delete, undelete, set-latest, and fingerprint-protected metadata updates. It also adds one compact `revert_workspace_entity` tool that calls all eight official revert methods for built-in variables, clients, tags, templates, transformations, triggers, variables, and zones. State-changing operations require explicit confirmation.

Validation:

- production-code inventory: exactly 101 distinct official GTM method call sites
- `go test ./... -count=1`
- `go vet ./...`
- `staticcheck ./...`
- schema report: default remains 64 tools / 78,734 bytes; `all` is 94 tools / 115,748 bytes
